### PR TITLE
Fallback to the on-disk DLL as Reference if the DLL isn't referenced in the solution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2023.1-Alpha-3
  * Fixed some instances of certain classes not being queried for their properties
+ * If you've got a project without the Assembly-CSharp.dll referenced (If you're on Linux for example), it should now be
+   able to find the DLL file on disk and reference that directly as a fall-back
 
 ## 2023.1-Alpha-2
  * Minimum Rider version is now 2023.1

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,6 @@
    * If we know a bit of XML should be an enum like Gender, we should be able to check that it's a valid enum value
 `  * Maybe bring out own Rimworld defs if there's no scope?
    * Handle Defs with custom classes instead of Rimworld classes
-`   * Packaging. It shouldn't be too difficult, but I haven't done it yet
    * We need to be able to support "LoadAlias", such as "StorageSettings.priority"
 
  * Autocomplete of special types
@@ -28,13 +27,10 @@
    * Make auto completing to other XMLTags look nicer and work faster
    * When linking to other def (`<defaultDuty>DefNameHere</defaultDuty>`) also include defs where the tag is a custom class
      that extends from the def we're looking for
-   
-` * Refactoring
-   * We're fetching symbol scopes a bit all over the place. Let's collect it into a SymbolScope helper class
 `   
  * Documentation
    * Re-read and document References.RimworldXmlReference
    * If you have an XML file open while Rider is still initializing, that file doesn't get autocompletion. Document that
    
  * Tests
-   * It's not a serious plugin project without Tests IMO. Let's at least aim to get one or two unit tests to start with
+   * It's not a serious project without Tests IMO. Let's at least aim to get one or two unit tests to start with

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ScopeHelper.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ScopeHelper.cs
@@ -1,8 +1,15 @@
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Application.Threading;
+using JetBrains.Metadata.Reader.API;
 using JetBrains.ProjectModel;
+using JetBrains.ProjectModel.Assemblies.Impl;
+using JetBrains.ProjectModel.model2.Assemblies.Interfaces;
+using JetBrains.ProjectModel.Model2.Assemblies.Interfaces;
 using JetBrains.ReSharper.Psi.Caches;
 using JetBrains.ReSharper.Psi.Modules;
+using JetBrains.ReSharper.TestFramework;
+using JetBrains.Util;
 
 namespace ReSharperPlugin.RimworldDev;
 
@@ -12,6 +19,7 @@ public class ScopeHelper
     private static ISymbolScope rimworldScope;
     private static IPsiModule rimworldModule;
     private static List<ISymbolScope> usedScopes;
+    private static bool adding = false;
 
     public static bool UpdateScopes(ISolution solution)
     {
@@ -24,7 +32,28 @@ public class ScopeHelper
         {
             rimworldScope = allScopes.FirstOrDefault(scope => scope.GetTypeElementByCLRName("Verse.ThingDef") != null);
 
-            if (rimworldScope == null) return false;
+            if (rimworldScope == null)
+            {
+                if (!adding)
+                {
+                    var location =
+                        "C:\\Program Files (x86)\\Steam\\steamapps\\common\\RimWorld\\RimWorldWin64_Data\\Managed\\Assembly-CSharp.dll";
+                    var path = FileSystemPath.TryParse(location);
+
+                    var moduleReferenceResolveContext =
+                        (IModuleReferenceResolveContext)UniversalModuleReferenceContext.Instance;
+
+                    IShellLocks shellLocks = solution.GetComponent<IShellLocks>();
+
+                    // using (shellLocks.UsingWriteLock("Src\\TestFramework\\BaseTestWithSolution.cs"))
+                        solution.GetComponent<IAssemblyFactory>().AddRef(path.ToAssemblyLocation(),
+                            "SolutionTestExtensions::AddAssembly", moduleReferenceResolveContext);
+
+                    adding = true;
+                }
+
+                return false;
+            };
             
             rimworldModule = solution.PsiModules().GetModules()
                 .First(module => module.GetPsiServices().Symbols.GetSymbolScope(module, true, true).GetTypeElementByCLRName("Verse.ThingDef") != null);

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ScopeHelper.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ScopeHelper.cs
@@ -56,8 +56,18 @@ public class ScopeHelper
         if (adding) return;
         adding = true;
 
-        var location =
-            "C:\\Program Files (x86)\\Steam\\steamapps\\common\\RimWorld\\RimWorldWin64_Data\\Managed\\Assembly-CSharp.dll";
+        var locations = new List<string>
+        {
+            "C:\\Program Files (x86)\\Steam\\steamapps\\common\\RimWorld\\RimWorldWin64_Data\\Managed\\Assembly-CSharp.dll",
+            "C:\\Program Files\\Steam\\steamapps\\common\\RimWorld\\RimWorldWin64_Data\\Managed\\Assembly-CSharp.dll",
+            "~/.steam/steam/SteamApps/common/RimWorld/RimWorldWin64_Data/Managed/Assembly-CSharp.dll"
+        };
+
+
+        var location = locations.FirstOrDefault(location => FileSystemPath.TryParse(location).ExistsFile);
+
+        if (location == null) return;
+        
         var path = FileSystemPath.TryParse(location);
 
         var moduleReferenceResolveContext =

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ScopeHelper.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ScopeHelper.cs
@@ -1,16 +1,11 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
-using JetBrains.Application.Threading;
 using JetBrains.Application.Threading.Tasks;
 using JetBrains.Metadata.Reader.API;
 using JetBrains.ProjectModel;
-using JetBrains.ProjectModel.Assemblies.Impl;
 using JetBrains.ProjectModel.model2.Assemblies.Interfaces;
-using JetBrains.ProjectModel.Model2.Assemblies.Interfaces;
 using JetBrains.ReSharper.Psi.Caches;
 using JetBrains.ReSharper.Psi.Modules;
-using JetBrains.ReSharper.TestFramework;
 using JetBrains.Util;
 using JetBrains.Util.Threading.Tasks;
 


### PR DESCRIPTION
If the solution doesn't include the `Assembly-CSharp.dll` as a dependency, we want to be able to try and find the DLL on-disk and use that as a reference for PSI Lookups instead. The target use-case for this is to support projects that are XML-only more easily