### PR TITLE
Add support for LoadFolders.xml

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,4 +34,3 @@
  * Project Structure
    * Add project references to allow mods to reference other mods
    * When the issue with the project location is fixed, move to 2023.3 to take advantage of that so that we don't need to build the structure ourselves
-   * Implement `loadFolders` to handle when Defs are in a version specific folder

--- a/TODO.md
+++ b/TODO.md
@@ -34,3 +34,6 @@
  * Project Structure
    * Add project references to allow mods to reference other mods
    * When the issue with the project location is fixed, move to 2023.3 to take advantage of that so that we don't need to build the structure ourselves
+
+ * Investigate the possibility of tying a version number to our types in the SymbolScope so that we can don't cross reference between versions
+   * Right now we only try to load the latest version of the XML, since we aren't built for loading multiple copies of the same def

--- a/src/dotnet/ReSharperPlugin.RimworldDev/RimworldXmlProject/Project/RimworldXmlProjectHost.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/RimworldXmlProject/Project/RimworldXmlProjectHost.cs
@@ -76,7 +76,7 @@ public class RimworldXmlProjectHost : SolutionFileProjectHostBase
 
         var byProjectLocation = ProjectDescriptor.CreateWithoutItemsByProjectDescriptor(customDescriptor);
         
-        myStructureBuilder.Build(byProjectLocation, ProjectFolderFilter.Instance);
+        myStructureBuilder.Build(byProjectLocation, ProjectFolderFilter.Instance, new List<string>());
         myWildcardService.RegisterDirectory(projectMark, siteProjectLocation, targetFramework, ProjectFolderFilter.Instance);
         
         change.Descriptors = new ProjectHostChangeDescriptors(byProjectLocation)

--- a/src/dotnet/ReSharperPlugin.RimworldDev/RimworldXmlProject/Project/RimworldXmlProjectHost.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/RimworldXmlProject/Project/RimworldXmlProjectHost.cs
@@ -97,7 +97,16 @@ public class RimworldXmlProjectHost : SolutionFileProjectHostBase
             var document = GetXmlDocument(loadFoldersFile.FullPath);
             if (document == null) return loadFolders;
 
-            var folderTags = document.GetElementsByTagName("li");
+            var versionList = new List<string>();
+            var versions = document.GetElementsByTagName("loadFolders")[0].ChildNodes;
+            for (var i = 0; i < versions.Count; i++)
+            {
+                versionList.Add(versions[i].Name);
+            }
+
+            versionList.Sort();
+            
+            var folderTags = document.GetElementsByTagName(versionList.Last())[0].ChildNodes;
             for (var i = 0; i < folderTags.Count; i++)
             {
                 if (!basePath.TryCombine(folderTags[i].InnerText).ExistsDirectory) continue;


### PR DESCRIPTION
This adds basic support for `LoadFolders.xml`. It doesn't mean that we're going to support XML for multiple versions (our symbol table isn't set up to handle multiple copies of the same def) so we just pick the latest version defined in the `LoadFolders.xml` and load the folders defined in that. 