### PR TITLE
Start adding support for custom def classes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -29,3 +29,5 @@
 
  * Refactor all reading of `About.xml` into a single class that holds that information for that file
  * Look at refactoring RimworldSymbolScope to see if we can make it cleaner
+ * Refactor the fetching of classes to a central location. We're all over the place, using different scopes from `ScopeHelper`
+   when we really should just let `ScopeHelper` deal with it all internally as well as the scope swapping

--- a/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldReferenceProvider.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldReferenceProvider.cs
@@ -110,12 +110,20 @@ public class RimworldReferenceFactory : IReferenceFactory
 
         var xmlSymbolTable = element.GetSolution().GetComponent<RimworldSymbolScope>();
 
-        var tagId = $"{classContext.ShortName}/{element.GetText()}";
-        if (xmlSymbolTable.GetTagByDef(classContext.ShortName, element.GetText()) is not { } tag)
+        var defType = classContext.ShortName;
+        var defName = element.GetText();
+        
+        if (xmlSymbolTable.ExtraDefTagNames.ContainsKey($"{defType}/{defName}"))
+        {
+            var newDef = xmlSymbolTable.ExtraDefTagNames[$"{defType}/{defName}"];
+            defType = newDef.Split('/').First();
+            defName = newDef.Split('/').Last();
+        }
+        
+        if (xmlSymbolTable.GetTagByDef(defType, defName) is not { } tag)
             return new ReferenceCollection();
-
-        return new ReferenceCollection(new RimworldXmlDefReference(element, tag, classContext.ShortName,
-            element.GetText()));
+        
+        return new ReferenceCollection(new RimworldXmlDefReference(element, tag, defType, defName));
     }
 
     /**

--- a/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldReferenceProvider.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldReferenceProvider.cs
@@ -58,7 +58,16 @@ public class RimworldReferenceFactory : IReferenceFactory
 
         if (hierarchy.Count == 0)
         {
-            var @class = rimworldSymbolScope.GetElementsByShortName(identifier.GetText()).FirstOrDefault();
+            var className = identifier.GetText();
+
+            var allWorkingScopes =
+                ScopeHelper.AllScopes.Where(scope => scope.GetTypeElementByCLRName(className) is not null);
+            
+            var @class = className.Contains(".")
+                ? ScopeHelper.GetScopeForClass(className).GetTypeElementByCLRName(className)
+                : rimworldSymbolScope.GetElementsByShortName(className).FirstOrDefault();
+            
+            if (@class == null) return new ReferenceCollection();
             return new ReferenceCollection(new RimworldXmlReference(@class, identifier));
         }
 
@@ -98,7 +107,7 @@ public class RimworldReferenceFactory : IReferenceFactory
 
         if (!ScopeHelper.ExtendsFromVerseDef(classContext.GetClrName().FullName))
             return new ReferenceCollection();
-        
+
         var xmlSymbolTable = element.GetSolution().GetComponent<RimworldSymbolScope>();
 
         var tagId = $"{classContext.ShortName}/{element.GetText()}";
@@ -127,14 +136,14 @@ public class RimworldReferenceFactory : IReferenceFactory
             .Children().First(childElement => childElement is XmlIdentifier).GetText();
 
         if (defTypeName is null) new ReferenceCollection();
-        
+
         var defName = element.GetText();
-        
+
         var xmlSymbolTable = element.GetSolution().GetComponent<RimworldSymbolScope>();
 
         var tagId = $"{defTypeName}/{defName}";
         if (!xmlSymbolTable.DefTags.ContainsKey(tagId)) return new ReferenceCollection();
-        
+
         if (xmlSymbolTable.GetTagByDef(defTypeName, defName) is not { } tag)
             return new ReferenceCollection();
 

--- a/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldXmlReference.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldXmlReference.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using JetBrains.Annotations;
 using JetBrains.Metadata.Reader.API;
 using JetBrains.ReSharper.Psi;
@@ -83,7 +84,7 @@ public class RimworldXmlReference :
         if (!useReferenceName)
             return table;
 
-        return table.Filter(GetName(), new AllFilter(myOwner.GetText()));
+        return table.Filter(GetName().Split('.').Last(), new AllFilter(myOwner.GetText().Split('.').Last()));
 
         // ISymbolTable table = this.myOwner.GetSolution().GetComponent<IHtmlDeclaredElementsCache>().GetAllTagsSymbolTable(this.myOwner.GetSourceFile()).Distinct(SymbolInfoComparer.OrdinalIgnoreCase);
         // if (useReferenceName)
@@ -104,7 +105,7 @@ public class RimworldXmlReference :
 
     public override ResolveResultWithInfo ResolveWithoutCache()
     {
-        ResolveResultWithInfo resolveResult = GetReferenceSymbolTable(true).GetResolveResult(GetName());
+        ResolveResultWithInfo resolveResult = GetReferenceSymbolTable(true).GetResolveResult(GetName().Split('.').Last());
         return resolveResult;
         // return new ResolveResultWithInfo(resolveResult.Result, resolveResult.Info.CheckResolveInfo((ResolveErrorType) HtmlResolveErrorType.UNKNOWN_HTML_TAG));
     }

--- a/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldXmlReference.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldXmlReference.cs
@@ -51,7 +51,8 @@ public class RimworldXmlReference :
     }
     
     public override string GetName() => myOwner.GetText();
-
+    private string GetShortName() => GetName().Split('.').Last();
+    
     public override TreeTextRange GetTreeTextRange() => myOwner.GetTreeTextRange();
 
     public override IAccessContext GetAccessContext() => new ElementAccessContext(myOwner);
@@ -84,12 +85,7 @@ public class RimworldXmlReference :
         if (!useReferenceName)
             return table;
 
-        return table.Filter(GetName().Split('.').Last(), new AllFilter(myOwner.GetText().Split('.').Last()));
-
-        // ISymbolTable table = this.myOwner.GetSolution().GetComponent<IHtmlDeclaredElementsCache>().GetAllTagsSymbolTable(this.myOwner.GetSourceFile()).Distinct(SymbolInfoComparer.OrdinalIgnoreCase);
-        // if (useReferenceName)
-        //     table = table.Filter(this.GetName());
-        // return table;
+        return table.Filter(GetShortName(), new AllFilter(GetShortName()));
     }
 
     public ISymbolTable GetCompletionSymbolTable() => GetReferenceSymbolTable(false);
@@ -105,9 +101,8 @@ public class RimworldXmlReference :
 
     public override ResolveResultWithInfo ResolveWithoutCache()
     {
-        ResolveResultWithInfo resolveResult = GetReferenceSymbolTable(true).GetResolveResult(GetName().Split('.').Last());
+        ResolveResultWithInfo resolveResult = GetReferenceSymbolTable(true).GetResolveResult(GetShortName());
         return resolveResult;
-        // return new ResolveResultWithInfo(resolveResult.Result, resolveResult.Info.CheckResolveInfo((ResolveErrorType) HtmlResolveErrorType.UNKNOWN_HTML_TAG));
     }
     
     public sealed class AllFilter : SimpleSymbolInfoFilter

--- a/src/dotnet/ReSharperPlugin.RimworldDev/RimworldXMLItemProvider.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/RimworldXMLItemProvider.cs
@@ -181,16 +181,17 @@ public class RimworldXMLItemProvider : ItemsProviderOfSpecificContext<RimworldXm
 
         var xmlSymbolTable = context.TreeNode!.GetSolution().GetSolution().GetComponent<RimworldSymbolScope>();
 
-        var keys = xmlSymbolTable.DefTags.Keys
-            .Where(key => key.StartsWith($"{className}/"))
-            .Select(key => key.Substring(className.Length + 1));
-
+        var keys = xmlSymbolTable.GetDefsByType(className);
+        
         foreach (var key in keys)
         {
-            var item = xmlSymbolTable.GetTagByDef(className, key);
-
-            var lookup = LookupFactory.CreateDeclaredElementLookupItem(context, key,
-                new DeclaredElementInstance(new XMLTagDeclaredElement(item, className, key, false)));
+            var defType = key.Split('/').First();
+            var defName = key.Split('/').Last();
+            
+            var item = xmlSymbolTable.GetTagByDef(defType, defName);
+            
+            var lookup = LookupFactory.CreateDeclaredElementLookupItem(context, defName,
+                new DeclaredElementInstance(new XMLTagDeclaredElement(item, defType, defName, false)));
             collector.Add(lookup);
         }
 

--- a/src/dotnet/ReSharperPlugin.RimworldDev/RimworldXMLItemProvider.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/RimworldXMLItemProvider.cs
@@ -348,8 +348,8 @@ public class RimworldXMLItemProvider : ItemsProviderOfSpecificContext<RimworldXm
                     classValue = Regex.Match(previousField.Type.GetLongPresentableName(CSharpLanguage.Instance),
                         @"^System.Collections.Generic.List<(.*?)>$").Groups[1].Value;
                 };
-                
-                currentContext = symbolScope.GetTypeElementByCLRName(classValue);
+
+                currentContext = ScopeHelper.GetScopeForClass(classValue).GetTypeElementByCLRName(classValue);
                 continue;
             }
 
@@ -362,12 +362,13 @@ public class RimworldXMLItemProvider : ItemsProviderOfSpecificContext<RimworldXm
 
                 if (classValue == "") return null;
 
+                var scopeToUse = ScopeHelper.GetScopeForClass(classValue);
                 // First we try to look it up as a short name from the Rimworld DLL
-                currentContext = symbolScope.GetElementsByShortName(classValue).FirstOrDefault() as ITypeElement;
+                currentContext = scopeToUse.GetElementsByShortName(classValue).FirstOrDefault() as ITypeElement;
                 if (currentContext != null) continue;
 
                 // Then we try to look it up as a fully qualified name from Rimworld
-                currentContext = symbolScope.GetTypeElementByCLRName(classValue);
+                currentContext = scopeToUse.GetTypeElementByCLRName(classValue);
                 if (currentContext != null) continue;
 
                 // If it's not a Rimworld class, let's assume that it's a custom class in our own C#. In that case, let's
@@ -388,7 +389,7 @@ public class RimworldXMLItemProvider : ItemsProviderOfSpecificContext<RimworldXm
             // current context to be diving into
             if (!currentContext.IsClass())
             {
-                currentContext = symbolScope.GetElementsByShortName(currentNode).FirstOrDefault() as Class;
+                currentContext = currentNode.Contains(".") ? ScopeHelper.GetScopeForClass(currentNode).GetTypeElementByCLRName(currentNode) : symbolScope.GetElementsByShortName(currentNode).FirstOrDefault() as Class;
                 continue;
             }
 
@@ -398,7 +399,7 @@ public class RimworldXMLItemProvider : ItemsProviderOfSpecificContext<RimworldXm
             previousField = field;
             var clrName = field.Type.GetLongPresentableName(CSharpLanguage.Instance);
 
-            currentContext = symbolScope.GetTypeElementByCLRName(clrName);
+            currentContext = ScopeHelper.GetScopeForClass(clrName).GetTypeElementByCLRName(clrName);
 
             switch (clrName)
             {

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ScopeHelper.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ScopeHelper.cs
@@ -19,6 +19,7 @@ namespace ReSharperPlugin.RimworldDev;
 public class ScopeHelper
 {
     private static List<ISymbolScope> allScopes = new();
+    private static List<ISymbolScope> knownCustomScopes = new();
     private static ISymbolScope rimworldScope;
     private static IPsiModule rimworldModule;
     private static List<ISymbolScope> usedScopes;
@@ -55,6 +56,22 @@ public class ScopeHelper
         }
 
         return true;
+    }
+
+    public static ISymbolScope GetScopeForClass(string className)
+    {
+        if (!className.Contains(".")) return rimworldScope;
+        if (knownCustomScopes.FirstOrDefault(scope => scope.GetTypeElementByCLRName(className) is not null) is
+            { } foundScope) return foundScope;
+
+        if (knownCustomScopes.FirstOrDefault(scope => scope.GetTypeElementByCLRName(className) is not null) is
+            { } newCustomScope)
+        {
+            knownCustomScopes.Add(newCustomScope);
+            return newCustomScope;
+        }
+        
+        return rimworldScope;
     }
 
     private static async void AddRef(ISolution solution)


### PR DESCRIPTION
This should handle one of my oldest feature requests and something I've wanted to do for a while, #3. It could still use some cleaning up though:

 * [ ] We should probably try to centralize the logic for fetching classes
 * [x] `RimworldXmlReference` should probably have a `GetShortName` instead of doing the `.` split in two places
 * [x] We need to get this working with Find Usages for custom def's base classes. Probably means registering the tag in our registry under multiple keys. One for each super class that we extend from