### PR TITLE
Add support for references from C# to XML

### DIFF
--- a/src/dotnet/ReSharperPlugin.RimworldDev/DefNameValue.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/DefNameValue.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+
+namespace ReSharperPlugin.RimworldDev;
+
+public class DefNameValue
+{
+    public readonly string DefType;
+    
+    public readonly string DefName;
+
+    public string TagId => $"{DefType}/{DefName}";
+
+    public DefNameValue(string tagId)
+    {
+        var split = tagId.Split('/');
+        DefType = split.First();
+        DefName = split.Last();
+    }
+    
+    public DefNameValue(string defType, string defName)
+    {
+        DefType = defType;
+        DefName = defName;
+    }
+}

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ItemCompletion/CSharpDefsOfItemProvider.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ItemCompletion/CSharpDefsOfItemProvider.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.CodeCompletion.Infrastructure;
+using JetBrains.ReSharper.Feature.Services.CodeCompletion.Infrastructure.LookupItems;
+using JetBrains.ReSharper.Feature.Services.CSharp.CodeCompletion.Infrastructure;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.Tree;
+using ReSharperPlugin.RimworldDev.SymbolScope;
+using ReSharperPlugin.RimworldDev.TypeDeclaration;
+
+namespace ReSharperPlugin.RimworldDev.ItemCompletion;
+
+[Language(typeof(CSharpLanguage))]
+public class CSharpDefsOfItemProvider : ItemsProviderOfSpecificContext<CSharpCodeCompletionContext>
+{
+    private static RimworldCSharpLookupFactory LookupFactory = new();
+
+    protected override bool IsAvailable(CSharpCodeCompletionContext context)
+    {
+        var node = context.NodeInFile;
+        if (!node.Language.IsLanguage(CSharpLanguage.Instance)) return false;
+        if (node.Parent is not IFieldDeclaration fieldDeclaration) return false;
+        if (fieldDeclaration.Type is not IDeclaredType) return false;
+        if (fieldDeclaration.GetContainingTypeElement() is not IClass containingClass) return false;
+        if (containingClass
+                .GetAttributeInstances(AttributesSource.Self)
+                .FirstOrDefault(attribute => attribute.GetClrName().FullName == "RimWorld.DefOf") is null) return false;
+
+        return true;
+    }
+
+    protected override bool AddLookupItems(CSharpCodeCompletionContext context, IItemsCollector collector)
+    {
+        var node = context.NodeInFile;
+
+        if (node.Parent is not IFieldDeclaration fieldDeclaration) return false;
+        if (fieldDeclaration.Type is not IDeclaredType fieldType) return false;
+
+        var defTypeName = fieldType.GetClrName().ShortName;
+        var xmlSymbolTable = context.NodeInFile.GetSolution().GetComponent<RimworldSymbolScope>();
+
+        var allDefs = xmlSymbolTable.GetDefsByType(defTypeName);
+
+        foreach (var key in allDefs)
+        {
+            var defType = key.Split('/').First();
+            var defName = key.Split('/').Last();
+
+            var item = xmlSymbolTable.GetTagByDef(defType, defName);
+
+            var lookup = LookupFactory.CreateDeclaredElementLookupItem(context, defName,
+                new DeclaredElementInstance(new XMLTagDeclaredElement(item, defType, defName, false)));
+            collector.Add(lookup);
+        }
+        
+        return base.AddLookupItems(context, collector);
+    }
+}

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ItemCompletion/RimworldDefCSharpItemProvider.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ItemCompletion/RimworldDefCSharpItemProvider.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.CodeCompletion.Infrastructure;
+using JetBrains.ReSharper.Feature.Services.CodeCompletion.Infrastructure.LookupItems;
+using JetBrains.ReSharper.Feature.Services.CSharp.CodeCompletion.Infrastructure;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Impl.Tree;
+using JetBrains.ReSharper.Psi.CSharp.Parsing;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.Tree;
+using ReSharperPlugin.RimworldDev.SymbolScope;
+using ReSharperPlugin.RimworldDev.TypeDeclaration;
+
+namespace ReSharperPlugin.RimworldDev.ItemCompletion;
+
+[Language(typeof(CSharpLanguage))]
+public class RimworldDefCSharpItemProvider: ItemsProviderOfSpecificContext<CSharpCodeCompletionContext>
+{
+    private static RimworldCSharpLookupFactory LookupFactory = new();
+    
+    protected override bool IsAvailable(CSharpCodeCompletionContext context)
+    {
+        var node = context.NodeInFile;
+        if (!node.Language.IsLanguage(CSharpLanguage.Instance)) return false;
+        if (node is not CSharpGenericToken) return false;
+        if (node.NodeType != CSharpTokenType.STRING_LITERAL_REGULAR) return false;
+        
+        return true;
+    }
+
+    protected override bool AddLookupItems(CSharpCodeCompletionContext context, IItemsCollector collector)
+    {
+        var node = context.NodeInFile;
+        if (node?.Parent?.Parent?.Parent?.Parent is not IInvocationExpression invocationExpression
+            || !invocationExpression.GetText().Contains("DefDatabase")
+            || invocationExpression.Type() is not IDeclaredType declaredType) return false;
+        
+        var defTypeName = declaredType.GetClrName().ShortName;
+        var xmlSymbolTable = context.NodeInFile.GetSolution().GetComponent<RimworldSymbolScope>();
+
+        var allDefs = xmlSymbolTable.GetDefsByType(defTypeName);
+        
+        foreach (var key in allDefs)
+        {
+            var defType = key.Split('/').First();
+            var defName = key.Split('/').Last();
+            
+            var item = xmlSymbolTable.GetTagByDef(defType, defName);
+            
+            var lookup = LookupFactory.CreateDeclaredElementLookupItem(context, defName,
+                new DeclaredElementInstance(new XMLTagDeclaredElement(item, defType, defName, false)));
+            collector.Add(lookup);
+        }
+        
+        return base.AddLookupItems(context, collector);
+    }
+}

--- a/src/dotnet/ReSharperPlugin.RimworldDev/Navigation/CustomSearcher.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/Navigation/CustomSearcher.cs
@@ -4,15 +4,17 @@ using JetBrains.Annotations;
 using JetBrains.Diagnostics;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Caches;
+using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.ExtensionsAPI;
 using JetBrains.ReSharper.Psi.ExtensionsAPI.Finder;
 using JetBrains.ReSharper.Psi.Files;
 using JetBrains.ReSharper.Psi.Search;
 using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.Xml;
 
 namespace ReSharperPlugin.RimworldDev.Navigation;
 
-public class CustomSearcher<TLanguage> : IDomainSpecificSearcher where TLanguage : KnownLanguage
+public class CustomSearcher : IDomainSpecificSearcher
 {
     private readonly JetHashSet<string> myNames;
     private readonly JetHashSet<string> myWordsInText;
@@ -50,7 +52,8 @@ public class CustomSearcher<TLanguage> : IDomainSpecificSearcher where TLanguage
     {
         if (!CanContainWord(sourceFile)) return false;
 
-        foreach (ITreeNode psiFile in sourceFile.GetPsiFiles<TLanguage>())
+        foreach (var psiFile in sourceFile.GetPsiFiles<XmlLanguage>()
+                     .Concat(sourceFile.GetPsiFiles<CSharpLanguage>()))
         {
             if (ProcessElement(psiFile, consumer))
                 return true;

--- a/src/dotnet/ReSharperPlugin.RimworldDev/Navigation/RimworldSearcherFactory.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/Navigation/RimworldSearcherFactory.cs
@@ -24,8 +24,7 @@ public class RimworldSearcherFactory(SearchDomainFactory searchDomainFactory) : 
         elements = new DeclaredElementsSet(elements.Where(element =>
             IsCompatibleWithLanguage(element.PresentationLanguage)));
         
-        return new CustomSearcher<XmlLanguage>(this,
-            elements, referenceSearcherParameters, false);
+        return new CustomSearcher(this, elements, referenceSearcherParameters, false);
     }
 
     public override IEnumerable<string> GetAllPossibleWordsInFile(IDeclaredElement element)

--- a/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldCSharpDefProvider.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldCSharpDefProvider.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Linq;
+using JetBrains.DataFlow;
+using JetBrains.Lifetimes;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.Caches;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.Resolve;
+using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.Util;
+using JetBrains.ReSharper.Psi.Web.WebConfig;
+using JetBrains.ReSharper.Psi.Xml;
+using JetBrains.ReSharper.Psi.Xml.Impl.Tree;
+using JetBrains.ReSharper.Psi.Xml.Tree;
+using ReSharperPlugin.RimworldDev.SymbolScope;
+
+
+namespace ReSharperPlugin.RimworldDev.TypeDeclaration;
+
+public class RimworldCSharpDefProvider
+{
+}
+
+[ReferenceProviderFactory]
+public class RimworldCSharpReferenceProvider : IReferenceProviderFactory
+{
+    public RimworldCSharpReferenceProvider(Lifetime lifetime) =>
+        Changed = new Signal<IReferenceProviderFactory>(lifetime, GetType().FullName);
+
+    public IReferenceFactory CreateFactory(IPsiSourceFile sourceFile, IFile file, IWordIndex wordIndexForChecks)
+    {
+        return sourceFile.PrimaryPsiLanguage.Is<CSharpLanguage>()
+            // && sourceFile.GetExtensionWithDot().Equals(".xml", StringComparison.CurrentCultureIgnoreCase)
+            ? new RimworldCSharpReferenceFactory()
+            : null;
+    }
+
+    public ISignal<IReferenceProviderFactory> Changed { get; }
+}
+
+/**
+ * The reference provider is just that, it provides a reference from XML into C# (And hopefully someday the other way
+ * around with Find Usages), where you can Ctrl+Click into the C# for a property or class
+ */
+public class RimworldCSharpReferenceFactory : IReferenceFactory
+{
+    public ReferenceCollection GetReferences(ITreeNode element, ReferenceCollection oldReferences)
+    {
+        if (element is ICSharpLiteralExpression expression &&
+            expression.Parent?.Parent?.Parent is IInvocationExpression invocationExpression &&
+            invocationExpression.GetText().Contains("DefDatabase") &&
+            invocationExpression.Type() is IDeclaredType declaredType)
+        {
+            var defTypeName = declaredType.GetClrName().ShortName;
+            var defName = element.GetText().Trim('"');
+            
+            var xmlSymbolTable = element.GetSolution().GetComponent<RimworldSymbolScope>();
+
+            var tagId = $"{defTypeName}/{defName}";
+            if (!xmlSymbolTable.DefTags.ContainsKey(tagId)) return new ReferenceCollection();
+
+            if (xmlSymbolTable.GetTagByDef(defTypeName, defName) is not { } tag)
+                return new ReferenceCollection();
+
+            return new ReferenceCollection(new RimworldXmlDefReference(element, tag, defTypeName,
+                element.GetText().Trim('"')));
+        }
+
+        if (element.GetContainingTypeElement() is not IClass containingClass || containingClass
+                .GetAttributeInstances(AttributesSource.Self)
+                .FirstOrDefault(attribute => attribute.GetClrName().FullName == "RimWorld.DefOf") is null)
+        {
+            return new ReferenceCollection();
+        }
+
+        if (element is IFieldDeclaration fieldDeclaration && fieldDeclaration.Type is IDeclaredType fieldType)
+        {
+            var defTypeName = fieldType.GetClrName().ShortName;
+            var defName = element.GetText();
+
+            var xmlSymbolTable = element.GetSolution().GetComponent<RimworldSymbolScope>();
+
+            var tagId = $"{defTypeName}/{defName}";
+            if (!xmlSymbolTable.DefTags.ContainsKey(tagId)) return new ReferenceCollection();
+
+            if (xmlSymbolTable.GetTagByDef(defTypeName, defName) is not { } tag)
+                return new ReferenceCollection();
+
+            return new ReferenceCollection(new RimworldXmlDefReference(element, tag, defTypeName,
+                element.GetText()));
+        }
+
+        return new ReferenceCollection();
+    }
+
+    public bool HasReference(ITreeNode element, IReferenceNameContainer names)
+    {
+        if (element.NodeType.ToString() != "TEXT") return false;
+        return !element.Parent.GetText().Contains("defName") && names.Contains(element.GetText());
+    }
+}

--- a/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldCSharpDefProvider.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldCSharpDefProvider.cs
@@ -59,6 +59,13 @@ public class RimworldCSharpReferenceFactory : IReferenceFactory
             var xmlSymbolTable = element.GetSolution().GetComponent<RimworldSymbolScope>();
 
             var tagId = $"{defTypeName}/{defName}";
+            if (xmlSymbolTable.ExtraDefTagNames.ContainsKey(tagId))
+            {
+                tagId = xmlSymbolTable.ExtraDefTagNames[tagId];
+                defTypeName = tagId.Split('/').First();
+                defName = tagId.Split('/').Last();
+            }
+            
             if (!xmlSymbolTable.DefTags.ContainsKey(tagId)) return new ReferenceCollection();
 
             if (xmlSymbolTable.GetTagByDef(defTypeName, defName) is not { } tag)
@@ -83,6 +90,13 @@ public class RimworldCSharpReferenceFactory : IReferenceFactory
             var xmlSymbolTable = element.GetSolution().GetComponent<RimworldSymbolScope>();
 
             var tagId = $"{defTypeName}/{defName}";
+            if (xmlSymbolTable.ExtraDefTagNames.ContainsKey(tagId))
+            {
+                tagId = xmlSymbolTable.ExtraDefTagNames[tagId];
+                defTypeName = tagId.Split('/').First();
+                defName = tagId.Split('/').Last();
+            }
+            
             if (!xmlSymbolTable.DefTags.ContainsKey(tagId)) return new ReferenceCollection();
 
             if (xmlSymbolTable.GetTagByDef(defTypeName, defName) is not { } tag)

--- a/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldCSharpDefProvider.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldCSharpDefProvider.cs
@@ -58,21 +58,15 @@ public class RimworldCSharpReferenceFactory : IReferenceFactory
             
             var xmlSymbolTable = element.GetSolution().GetComponent<RimworldSymbolScope>();
 
-            var tagId = $"{defTypeName}/{defName}";
-            if (xmlSymbolTable.ExtraDefTagNames.ContainsKey(tagId))
-            {
-                tagId = xmlSymbolTable.ExtraDefTagNames[tagId];
-                defTypeName = tagId.Split('/').First();
-                defName = tagId.Split('/').Last();
-            }
+            var defNameTag = new DefNameValue(defTypeName, defName);
+            defNameTag = xmlSymbolTable.GetDefName(defNameTag);
             
-            if (!xmlSymbolTable.DefTags.ContainsKey(tagId)) return new ReferenceCollection();
+            if (!xmlSymbolTable.HasTag(defNameTag)) return new ReferenceCollection();
 
-            if (xmlSymbolTable.GetTagByDef(defTypeName, defName) is not { } tag)
+            if (xmlSymbolTable.GetTagByDef(defNameTag) is not { } tag)
                 return new ReferenceCollection();
 
-            return new ReferenceCollection(new RimworldXmlDefReference(element, tag, defTypeName,
-                element.GetText().Trim('"')));
+            return new ReferenceCollection(new RimworldXmlDefReference(element, tag, defNameTag.DefType, defNameTag.DefName));
         }
 
         if (element.GetContainingTypeElement() is not IClass containingClass || containingClass
@@ -89,21 +83,15 @@ public class RimworldCSharpReferenceFactory : IReferenceFactory
 
             var xmlSymbolTable = element.GetSolution().GetComponent<RimworldSymbolScope>();
 
-            var tagId = $"{defTypeName}/{defName}";
-            if (xmlSymbolTable.ExtraDefTagNames.ContainsKey(tagId))
-            {
-                tagId = xmlSymbolTable.ExtraDefTagNames[tagId];
-                defTypeName = tagId.Split('/').First();
-                defName = tagId.Split('/').Last();
-            }
+            var defNameTag = new DefNameValue(defTypeName, defName);
+            defNameTag = xmlSymbolTable.GetDefName(defNameTag);
             
-            if (!xmlSymbolTable.DefTags.ContainsKey(tagId)) return new ReferenceCollection();
+            if (!xmlSymbolTable.HasTag(defNameTag)) return new ReferenceCollection();
 
-            if (xmlSymbolTable.GetTagByDef(defTypeName, defName) is not { } tag)
+            if (xmlSymbolTable.GetTagByDef(defNameTag) is not { } tag)
                 return new ReferenceCollection();
 
-            return new ReferenceCollection(new RimworldXmlDefReference(element, tag, defTypeName,
-                element.GetText()));
+            return new ReferenceCollection(new RimworldXmlDefReference(element, tag, defNameTag.DefType, defNameTag.DefName));
         }
 
         return new ReferenceCollection();

--- a/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldReferenceProvider.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldReferenceProvider.cs
@@ -113,17 +113,13 @@ public class RimworldReferenceFactory : IReferenceFactory
         var defType = classContext.ShortName;
         var defName = element.GetText();
         
-        if (xmlSymbolTable.ExtraDefTagNames.ContainsKey($"{defType}/{defName}"))
-        {
-            var newDef = xmlSymbolTable.ExtraDefTagNames[$"{defType}/{defName}"];
-            defType = newDef.Split('/').First();
-            defName = newDef.Split('/').Last();
-        }
+        var defNameTag = new DefNameValue(defType, defName);
+        defNameTag = xmlSymbolTable.GetDefName(defNameTag);
         
-        if (xmlSymbolTable.GetTagByDef(defType, defName) is not { } tag)
+        if (xmlSymbolTable.GetTagByDef(defNameTag) is not { } tag)
             return new ReferenceCollection();
         
-        return new ReferenceCollection(new RimworldXmlDefReference(element, tag, defType, defName));
+        return new ReferenceCollection(new RimworldXmlDefReference(element, tag, defNameTag.DefType, defNameTag.DefName));
     }
 
     /**
@@ -149,14 +145,15 @@ public class RimworldReferenceFactory : IReferenceFactory
 
         var xmlSymbolTable = element.GetSolution().GetComponent<RimworldSymbolScope>();
 
-        var tagId = $"{defTypeName}/{defName}";
-        if (!xmlSymbolTable.DefTags.ContainsKey(tagId)) return new ReferenceCollection();
+        var defNameTag = new DefNameValue(defTypeName, defName);
+        if (!xmlSymbolTable.HasTag(defNameTag)) return new ReferenceCollection();
+        defNameTag = xmlSymbolTable.GetDefName(defNameTag);
 
-        if (xmlSymbolTable.GetTagByDef(defTypeName, defName) is not { } tag)
+        if (xmlSymbolTable.GetTagByDef(defNameTag) is not { } tag)
             return new ReferenceCollection();
 
-        return new ReferenceCollection(new RimworldXmlDefReference(element, tag, defTypeName,
-            element.GetText()));
+        return new ReferenceCollection(new RimworldXmlDefReference(element, tag, defNameTag.DefType,
+            defNameTag.DefName));
     }
 
     public bool HasReference(ITreeNode element, IReferenceNameContainer names)

--- a/src/dotnet/ReSharperPlugin.RimworldDev/RimworldCSharpLookupFactory.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/RimworldCSharpLookupFactory.cs
@@ -1,15 +1,15 @@
 using System;
-using System.Collections.Generic;
-using System.Drawing;
 using System.Text;
 using JetBrains.Annotations;
 using JetBrains.Diagnostics;
+using JetBrains.DocumentModel;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.CodeCompletion.Infrastructure;
 using JetBrains.ReSharper.Feature.Services.CodeCompletion.Infrastructure.AspectLookupItems.BaseInfrastructure;
 using JetBrains.ReSharper.Feature.Services.CodeCompletion.Infrastructure.AspectLookupItems.Info;
 using JetBrains.ReSharper.Feature.Services.CodeCompletion.Infrastructure.AspectLookupItems.Matchers;
 using JetBrains.ReSharper.Feature.Services.CodeCompletion.Infrastructure.AspectLookupItems.Presentations;
+using JetBrains.ReSharper.Feature.Services.CSharp.CodeCompletion.Infrastructure;
 using JetBrains.ReSharper.Features.Intellisense.CodeCompletion.CSharp;
 using JetBrains.ReSharper.Features.Intellisense.CodeCompletion.CSharp.AspectLookupItems;
 using JetBrains.ReSharper.Psi;
@@ -32,176 +32,296 @@ namespace ReSharperPlugin.RimworldDev;
 
 public class RimworldCSharpLookupFactory
 {
-  private readonly Func<LookupItem<CSharpDeclaredElementInfo>, ILookupItemPresentation> myFGetDeclaredElementPresentation = (item =>
-  {
-    var info = item.Info;
-    var nullable = new bool?();
-    IUnresolvedDeclaredElement unresolvedDeclaredElement = null;
-    var preferredDeclaredElement = info.PreferredDeclaredElement;
-    if (preferredDeclaredElement != null)
-    {
-      var element = preferredDeclaredElement.Element;
-      if (element is ITypeParameter)
-        nullable = info.Owner.Services.DeclaredElementDescriptionPresenter.IsDeclaredElementObsolete(element);
-      unresolvedDeclaredElement = element as IUnresolvedDeclaredElement;
-    }
-    var presentation = GetOrCreatePresentation(info, PresenterStyles.DefaultPresenterStyle);
-    if (nullable.HasValue)
-      presentation.IsObsolete = nullable.Value;
-    if (unresolvedDeclaredElement != null)
-      presentation.TextColor = unresolvedDeclaredElement.IsDynamic ? JetRgbaColors.Blue : JetRgbaColors.Red;
-    return presentation;
-  });
-  
-  private readonly Func<LookupItem<CSharpDeclaredElementInfo>, ILookupItemPresentation> myFGetLocalFunctionPresentationWithoutSignature = item => GetOrCreatePresentation(item.Info, PresenterStyles.DefaultNoParametersPresenter);
-  private readonly Func<LookupItem<CSharpDeclaredElementInfo>, ILookupItemBehavior> myFGetDeclaredElementBehavior = item => new CSharpDeclaredElementBehavior<CSharpDeclaredElementInfo>(item);
-  private readonly Func<LookupItem<CSharpDeclaredElementInfo>, ILookupItemMatcher> myFGetDeclaredElementMatcher = item => new DeclaredElementMatcher(item.Info, "@");
-  private readonly Func<LookupItem<TypeElementInfo>, ILookupItemBehavior> myFGetTypeElementBehavior = item => new CSharpDeclaredElementBehavior<TypeElementInfo>(item);
-  private readonly Func<LookupItem<TypeElementInfo>, ILookupItemPresentation> myFGetTypeElementPresentation = item =>
-  {
-    var info = item.Info;
-    var style = info.InsertAngleBrackets ? PresenterStyles.TypeElementPresenterStyle : PresenterStyles.TypeShortNamePresenterStyle;
-    var presentation = GetOrCreatePresentation(info, style);
-    presentation.VisualReplaceRangeMarker = info.Ranges.CreateVisualReplaceRangeMarker();
-    return presentation;
-  };
-  
-  private static DeclaredElementPresentation<DeclaredElementInfo> GetOrCreatePresentation(
-    [NotNull] DeclaredElementInfo info,
-    DeclaredElementPresenterStyle style,
-    [CanBeNull] string typeParameterString = null)
-  {
-    var preferredDeclaredElement = info.PreferredDeclaredElement;
-    var name = info.Text;
-    if (preferredDeclaredElement != null && preferredDeclaredElement.Element is ICompiledElement element &&
-        element.Type() == null)
-      return GetPresentationCache(element.GetSolution()).GetPresentation(info, element, style, typeParameterString);
-    else
-      return new DeclaredElementPresentation<DeclaredElementInfo>(info, style, typeParameterString);
-  }
-  
-  private static LookupItemPresentationCache GetPresentationCache(
-    [NotNull] ISolution solution)
-  {
-    var presentationCache1 = ourPresentationCache;
-    if (presentationCache1 != null)
-      return presentationCache1;
-    var presentationCache2 = ourPresentationCache = solution.GetComponent<LookupItemPresentationCache>();
-    solution.GetSolutionLifetimes().MaximumLifetime.OnTermination(() => ourPresentationCache = null);
-    return presentationCache2;
-  }
-  
-  private static LookupItemPresentationCache ourPresentationCache;
-
-
-  public LookupItem<CSharpDeclaredElementInfo> CreateDeclaredElementLookupItem(
-      [NotNull] RimworldXmlCodeCompletionContext context,
-      [NotNull] string name,
-      [NotNull] DeclaredElementInstance instance,
-      bool includeFollowingExpression = true,
-      bool bind = false,
-      QualifierKind qualifierKind = QualifierKind.NONE)
-    {
-      Assertion.Assert(instance != null && instance.IsValid(), "instance != null && instance.IsValid()");
-      var basicContext = context.BasicContext;
-      var declaredElementInfo = new CSharpDeclaredElementInfo(name, instance, basicContext.LookupItemsOwner, context)
+    private readonly Func<LookupItem<CSharpDeclaredElementInfo>, ILookupItemPresentation>
+        myFGetDeclaredElementPresentation = (item =>
         {
-          Bind = bind,
-          Ranges = context.Ranges
+            var info = item.Info;
+            var nullable = new bool?();
+            IUnresolvedDeclaredElement unresolvedDeclaredElement = null;
+            var preferredDeclaredElement = info.PreferredDeclaredElement;
+            if (preferredDeclaredElement != null)
+            {
+                var element = preferredDeclaredElement.Element;
+                if (element is ITypeParameter)
+                    nullable =
+                        info.Owner.Services.DeclaredElementDescriptionPresenter.IsDeclaredElementObsolete(element);
+                unresolvedDeclaredElement = element as IUnresolvedDeclaredElement;
+            }
+
+            var presentation = GetOrCreatePresentation(info, PresenterStyles.DefaultPresenterStyle);
+            if (nullable.HasValue)
+                presentation.IsObsolete = nullable.Value;
+            if (unresolvedDeclaredElement != null)
+                presentation.TextColor = unresolvedDeclaredElement.IsDynamic ? JetRgbaColors.Blue : JetRgbaColors.Red;
+            return presentation;
+        });
+
+    private readonly Func<LookupItem<CSharpDeclaredElementInfo>, ILookupItemPresentation>
+        myFGetLocalFunctionPresentationWithoutSignature = item =>
+            GetOrCreatePresentation(item.Info, PresenterStyles.DefaultNoParametersPresenter);
+
+    private readonly Func<LookupItem<CSharpDeclaredElementInfo>, ILookupItemBehavior> myFGetDeclaredElementBehavior =
+        item => new CSharpDeclaredElementBehavior<CSharpDeclaredElementInfo>(item);
+
+    private readonly Func<LookupItem<CSharpDeclaredElementInfo>, ILookupItemMatcher> myFGetDeclaredElementMatcher =
+        item => new DeclaredElementMatcher(item.Info, "@");
+
+    private readonly Func<LookupItem<TypeElementInfo>, ILookupItemBehavior> myFGetTypeElementBehavior =
+        item => new CSharpDeclaredElementBehavior<TypeElementInfo>(item);
+
+    private readonly Func<LookupItem<TypeElementInfo>, ILookupItemPresentation> myFGetTypeElementPresentation = item =>
+    {
+        var info = item.Info;
+        var style = info.InsertAngleBrackets
+            ? PresenterStyles.TypeElementPresenterStyle
+            : PresenterStyles.TypeShortNamePresenterStyle;
+        var presentation = GetOrCreatePresentation(info, style);
+        presentation.VisualReplaceRangeMarker = info.Ranges.CreateVisualReplaceRangeMarker();
+        return presentation;
+    };
+
+    private static DeclaredElementPresentation<DeclaredElementInfo> GetOrCreatePresentation(
+        [NotNull] DeclaredElementInfo info,
+        DeclaredElementPresenterStyle style,
+        [CanBeNull] string typeParameterString = null)
+    {
+        var preferredDeclaredElement = info.PreferredDeclaredElement;
+        var name = info.Text;
+        if (preferredDeclaredElement != null && preferredDeclaredElement.Element is ICompiledElement element &&
+            element.Type() == null)
+            return GetPresentationCache(element.GetSolution())
+                .GetPresentation(info, element, style, typeParameterString);
+        else
+            return new DeclaredElementPresentation<DeclaredElementInfo>(info, style, typeParameterString);
+    }
+
+    private static LookupItemPresentationCache GetPresentationCache(
+        [NotNull] ISolution solution)
+    {
+        var presentationCache1 = ourPresentationCache;
+        if (presentationCache1 != null)
+            return presentationCache1;
+        var presentationCache2 = ourPresentationCache = solution.GetComponent<LookupItemPresentationCache>();
+        solution.GetSolutionLifetimes().MaximumLifetime.OnTermination(() => ourPresentationCache = null);
+        return presentationCache2;
+    }
+
+    private static LookupItemPresentationCache ourPresentationCache;
+
+    // @TODO: See if we can merge both lookup creations together and just have thin interfaces
+    public LookupItem<CSharpDeclaredElementInfo> CreateDeclaredElementLookupItem(
+        [NotNull] CSharpCodeCompletionContext context,
+        [NotNull] string name,
+        [NotNull] DeclaredElementInstance instance,
+        bool includeFollowingExpression = true,
+        bool bind = false,
+        QualifierKind qualifierKind = QualifierKind.NONE)
+    {
+        Assertion.Assert(instance != null && instance.IsValid(), "instance != null && instance.IsValid()");
+        var basicContext = context.BasicContext;
+        var replaceRange = context.CompletionRanges.ReplaceRange;
+
+        // @TODO: Find out why we needed to do this
+        if (context.NodeInFile.GetText().StartsWith("\""))
+        {
+            replaceRange = new DocumentRange(replaceRange.Document,
+                new TextRange(replaceRange.TextRange.StartOffset + 1, replaceRange.TextRange.EndOffset - 1));
+        }
+
+        var completionRange = new TextLookupRanges(replaceRange, replaceRange, null, false);
+        // var completionRange = context.CompletionRanges;
+        
+        var declaredElementInfo = new CSharpDeclaredElementInfo(name, instance, basicContext.LookupItemsOwner, context)
+        {
+            Bind = bind,
+            Ranges = completionRange
         };
 
-      var element = instance.Element;
-      if (element is ITypeElement typeElement && typeElement.HasTypeParameters())
-      {
-        declaredElementInfo.AppendToIdentity(2);
-        declaredElementInfo.Placement.OrderString += "<>";
-      }
-      
-      if (qualifierKind != QualifierKind.NONE)
-        declaredElementInfo.QualifierKind = qualifierKind;
-      
-      if (element is IField field)
-      {
-        if (!field.GetContainingType().IsValueTuple())
-          declaredElementInfo.Bind = true;
-      }
-      else if (element is ITypeElement)
-      {
-        declaredElementInfo.Bind = true;
-        if (element is not ITypeParameter)
-          declaredElementInfo.IsTypeElement = true;
-      }
-      
-      switch (element)
-      {
-        case IExternAlias:
-          declaredElementInfo.TailType = CSharpTailType.DoubleColon;
-          break;
-        case IClass:
-        case IStruct:
-          declaredElementInfo.Placement.OrderString += " T";
-          break;
-        case IProperty:
-          declaredElementInfo.Placement.OrderString += " P";
-          break;
-      }
-
-      if (element is not IParametersOwner declaredElement)
-        declaredElement = (element as IDelegate).IfNotNull(_ => _.InvokeMethod);
-      
-      if (declaredElement != null && (context.BasicContext.ShowSignatures || element is IUnresolvedDeclaredElement) && declaredElement.Parameters.Count > 0 && !declaredElement.IsCSharpProperty())
-      {
-        var stringBuilder = new StringBuilder();
-        var parameters = declaredElement.Parameters;
-        for (var index = 0; index < parameters.Count; ++index)
+        var element = instance.Element;
+        if (element is ITypeElement typeElement && typeElement.HasTypeParameters())
         {
-          var type = parameters[index].Type;
-          stringBuilder.Append((parameters[index].IsParameterArray ? "params" : string.Empty) + type.GetPresentableName(CSharpLanguage.Instance));
-          if (index < parameters.Count - 1)
-            stringBuilder.Append(", ");
+            declaredElementInfo.AppendToIdentity(2);
+            declaredElementInfo.Placement.OrderString += "<>";
         }
-        declaredElementInfo.Placement.OrderString = name + "(" + stringBuilder + ")";
-      }
-      var fGetPresentation = myFGetDeclaredElementPresentation;
-      if (element is ILocalFunction && !context.BasicContext.ShowSignatures)
-        fGetPresentation = myFGetLocalFunctionPresentationWithoutSignature;
-      var dataHolder = LookupItemFactory.CreateLookupItem(declaredElementInfo)
-        .WithPresentation(fGetPresentation)
-        .WithBehavior(myFGetDeclaredElementBehavior)
-        .WithMatcher(myFGetDeclaredElementMatcher);
 
-      var typeOwner = element as ITypeOwner;
-      if (instance.Element is IAnonymousTypeProperty)
-        declaredElementInfo.HighlightSameType = true;
-      IDelegate @delegate = null;
-      if (typeOwner != null && GetType(typeOwner) is IDeclaredType type1)
-        @delegate = type1.GetTypeElement() as IDelegate;
-      if (element is ITypeElement || element is INamespace)
-        dataHolder.PutKey(CompletionKeys.IsTypeOrNamespaceKey);
-      // if (@delegate == null && !(element1 is ITypeElement) && context.ReplaceRangeWithJoinedArguments.IsValid())
-      // {
-      //   TextLookupRanges textLookupRanges = context.CompletionRanges.WithReplaceRange(context.ReplaceRangeWithJoinedArguments);
-      //   dataHolder.Info.Ranges = textLookupRanges;
-      // }
-      // if (qualifierKind == QualifierKind.NONE && context.UnterminatedContext.Reference is IQualifiableReference reference)
-      // {
-      //   IQualifier qualifier = reference.GetQualifier();
-      //   qualifierKind = qualifier != null ? qualifier.GetKind() : QualifierKind.NONE;
-      //   dataHolder.PutData<object>((Key<object>) CompletionKeys.ContextQualifierKind, (object) qualifierKind);
-      // }
-      if (name == "hediff")
-      {
-        var displayText = dataHolder.DisplayTypeName;
-      }
-      
-      return dataHolder;
+        if (qualifierKind != QualifierKind.NONE)
+            declaredElementInfo.QualifierKind = qualifierKind;
+
+        if (element is IField field)
+        {
+            if (!field.GetContainingType().IsValueTuple())
+                declaredElementInfo.Bind = true;
+        }
+        else if (element is ITypeElement)
+        {
+            declaredElementInfo.Bind = true;
+            if (element is not ITypeParameter)
+                declaredElementInfo.IsTypeElement = true;
+        }
+
+        switch (element)
+        {
+            case IExternAlias:
+                declaredElementInfo.TailType = CSharpTailType.DoubleColon;
+                break;
+            case IClass:
+            case IStruct:
+                declaredElementInfo.Placement.OrderString += " T";
+                break;
+            case IProperty:
+                declaredElementInfo.Placement.OrderString += " P";
+                break;
+        }
+
+        if (element is not IParametersOwner declaredElement)
+            declaredElement = (element as IDelegate).IfNotNull(_ => _.InvokeMethod);
+
+        if (declaredElement != null && (context.BasicContext.ShowSignatures || element is IUnresolvedDeclaredElement) &&
+            declaredElement.Parameters.Count > 0 && !declaredElement.IsCSharpProperty())
+        {
+            var stringBuilder = new StringBuilder();
+            var parameters = declaredElement.Parameters;
+            for (var index = 0; index < parameters.Count; ++index)
+            {
+                var type = parameters[index].Type;
+                stringBuilder.Append((parameters[index].IsParameterArray ? "params" : string.Empty) +
+                                     type.GetPresentableName(CSharpLanguage.Instance));
+                if (index < parameters.Count - 1)
+                    stringBuilder.Append(", ");
+            }
+
+            declaredElementInfo.Placement.OrderString = name + "(" + stringBuilder + ")";
+        }
+
+        var fGetPresentation = myFGetDeclaredElementPresentation;
+        if (element is ILocalFunction && !context.BasicContext.ShowSignatures)
+            fGetPresentation = myFGetLocalFunctionPresentationWithoutSignature;
+        var dataHolder = LookupItemFactory.CreateLookupItem(declaredElementInfo)
+            .WithPresentation(fGetPresentation)
+            .WithBehavior(myFGetDeclaredElementBehavior)
+            .WithMatcher(myFGetDeclaredElementMatcher);
+
+        var typeOwner = element as ITypeOwner;
+        if (instance.Element is IAnonymousTypeProperty)
+            declaredElementInfo.HighlightSameType = true;
+        IDelegate @delegate = null;
+        if (typeOwner != null && GetType(typeOwner) is IDeclaredType type1)
+            @delegate = type1.GetTypeElement() as IDelegate;
+        if (element is ITypeElement || element is INamespace)
+            dataHolder.PutKey(CompletionKeys.IsTypeOrNamespaceKey);
+
+        if (name == "hediff")
+        {
+            var displayText = dataHolder.DisplayTypeName;
+        }
+
+        return dataHolder;
     }
-  
-  [CanBeNull]
-  private static IType GetType([NotNull] ITypeOwner typeOwner)
-  {
-    if (!(typeOwner is ILocalVariableDeclaration variableDeclaration) || !variableDeclaration.IsVar)
-      return typeOwner.Type;
-    return !(variableDeclaration is IManagedVariableImpl managedVariableImpl) ? null : managedVariableImpl.CachedType;
-  }
+
+    public LookupItem<CSharpDeclaredElementInfo> CreateDeclaredElementLookupItem(
+        [NotNull] RimworldXmlCodeCompletionContext context,
+        [NotNull] string name,
+        [NotNull] DeclaredElementInstance instance,
+        bool includeFollowingExpression = true,
+        bool bind = false,
+        QualifierKind qualifierKind = QualifierKind.NONE)
+    {
+        Assertion.Assert(instance != null && instance.IsValid(), "instance != null && instance.IsValid()");
+        var basicContext = context.BasicContext;
+        var declaredElementInfo = new CSharpDeclaredElementInfo(name, instance, basicContext.LookupItemsOwner, context)
+        {
+            Bind = bind,
+            Ranges = context.Ranges
+        };
+
+        var element = instance.Element;
+        if (element is ITypeElement typeElement && typeElement.HasTypeParameters())
+        {
+            declaredElementInfo.AppendToIdentity(2);
+            declaredElementInfo.Placement.OrderString += "<>";
+        }
+
+        if (qualifierKind != QualifierKind.NONE)
+            declaredElementInfo.QualifierKind = qualifierKind;
+
+        if (element is IField field)
+        {
+            if (!field.GetContainingType().IsValueTuple())
+                declaredElementInfo.Bind = true;
+        }
+        else if (element is ITypeElement)
+        {
+            declaredElementInfo.Bind = true;
+            if (element is not ITypeParameter)
+                declaredElementInfo.IsTypeElement = true;
+        }
+
+        switch (element)
+        {
+            case IExternAlias:
+                declaredElementInfo.TailType = CSharpTailType.DoubleColon;
+                break;
+            case IClass:
+            case IStruct:
+                declaredElementInfo.Placement.OrderString += " T";
+                break;
+            case IProperty:
+                declaredElementInfo.Placement.OrderString += " P";
+                break;
+        }
+
+        if (element is not IParametersOwner declaredElement)
+            declaredElement = (element as IDelegate).IfNotNull(_ => _.InvokeMethod);
+
+        if (declaredElement != null && (context.BasicContext.ShowSignatures || element is IUnresolvedDeclaredElement) &&
+            declaredElement.Parameters.Count > 0 && !declaredElement.IsCSharpProperty())
+        {
+            var stringBuilder = new StringBuilder();
+            var parameters = declaredElement.Parameters;
+            for (var index = 0; index < parameters.Count; ++index)
+            {
+                var type = parameters[index].Type;
+                stringBuilder.Append((parameters[index].IsParameterArray ? "params" : string.Empty) +
+                                     type.GetPresentableName(CSharpLanguage.Instance));
+                if (index < parameters.Count - 1)
+                    stringBuilder.Append(", ");
+            }
+
+            declaredElementInfo.Placement.OrderString = name + "(" + stringBuilder + ")";
+        }
+
+        var fGetPresentation = myFGetDeclaredElementPresentation;
+        if (element is ILocalFunction && !context.BasicContext.ShowSignatures)
+            fGetPresentation = myFGetLocalFunctionPresentationWithoutSignature;
+        var dataHolder = LookupItemFactory.CreateLookupItem(declaredElementInfo)
+            .WithPresentation(fGetPresentation)
+            .WithBehavior(myFGetDeclaredElementBehavior)
+            .WithMatcher(myFGetDeclaredElementMatcher);
+
+        var typeOwner = element as ITypeOwner;
+        if (instance.Element is IAnonymousTypeProperty)
+            declaredElementInfo.HighlightSameType = true;
+        IDelegate @delegate = null;
+        if (typeOwner != null && GetType(typeOwner) is IDeclaredType type1)
+            @delegate = type1.GetTypeElement() as IDelegate;
+        if (element is ITypeElement || element is INamespace)
+            dataHolder.PutKey(CompletionKeys.IsTypeOrNamespaceKey);
+
+        if (name == "hediff")
+        {
+            var displayText = dataHolder.DisplayTypeName;
+        }
+
+        return dataHolder;
+    }
+
+    [CanBeNull]
+    private static IType GetType([NotNull] ITypeOwner typeOwner)
+    {
+        if (!(typeOwner is ILocalVariableDeclaration variableDeclaration) || !variableDeclaration.IsVar)
+            return typeOwner.Type;
+        return !(variableDeclaration is IManagedVariableImpl managedVariableImpl)
+            ? null
+            : managedVariableImpl.CachedType;
+    }
 }

--- a/src/dotnet/ReSharperPlugin.RimworldDev/SymbolScope/RimworldSymbolScope.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/SymbolScope/RimworldSymbolScope.cs
@@ -21,9 +21,8 @@ namespace ReSharperPlugin.RimworldDev.SymbolScope;
 [PsiComponent]
 public class RimworldSymbolScope : SimpleICache<List<RimworldXmlDefSymbol>>
 {
-    public Dictionary<string, ITreeNode> DefTags = new();
-
-    public Dictionary<string, string> ExtraDefTagNames = new();
+    private Dictionary<string, ITreeNode> DefTags = new();
+    private Dictionary<string, string> ExtraDefTagNames = new();
     private Dictionary<string, XMLTagDeclaredElement> _declaredElements = new();
     private SymbolTable _symbolTable;
 
@@ -39,11 +38,17 @@ public class RimworldSymbolScope : SimpleICache<List<RimworldXmlDefSymbol>>
         return base.IsApplicable(sourceFile) && sourceFile.LanguageType.Name == "XML";
     }
 
+    public bool HasTag(DefNameValue defName) =>
+        DefTags.ContainsKey(defName.TagId) || ExtraDefTagNames.ContainsKey(defName.TagId);
+
     [CanBeNull]
     public ITreeNode GetTagByDef(string defType, string defName)
     {
         return GetTagByDef($"{defType}/{defName}");
     }
+
+    [CanBeNull]
+    public ITreeNode GetTagByDef(DefNameValue defName) => GetTagByDef(defName.TagId);
 
     [CanBeNull]
     public ITreeNode GetTagByDef(string defId)
@@ -53,6 +58,9 @@ public class RimworldSymbolScope : SimpleICache<List<RimworldXmlDefSymbol>>
 
         return DefTags[defId];
     }
+
+    public DefNameValue GetDefName(DefNameValue value) =>
+        ExtraDefTagNames.TryGetValue(value.TagId, out var defTag) ? new DefNameValue(defTag) : value;
 
     public List<string> GetDefsByType(string defType)
     {


### PR DESCRIPTION
This PR will probably be open for a while, here's the list of features that we need to implement

 * [x] Creating a reference from classes that have the `[DefOf]` attribute back to XML
 * [x] Creating a reference from the text in `DefDatabase.GetNamed` back to XML
 * [x] Make sure those references work with Custom Def Classes
 * [x] Have the XML Def `Find Usages` return those C# References
 * [x] Add ItemProvider for autocomplete in CSharp Contexts