### PR TITLE
Get debug working on linux

### DIFF
--- a/src/rider/main/resources/UnityDoorstop/Linux/run.sh
+++ b/src/rider/main/resources/UnityDoorstop/Linux/run.sh
@@ -23,7 +23,7 @@ enabled="1"
 
 # Path to the assembly to load and execute
 # NOTE: The entrypoint must be of format `static void Doorstop.Entrypoint.Start()`
-target_assembly="Doorstop.dll"
+target_assembly="Doorstop/Doorstop.dll"
 
 # Overrides the default boot.config file path
 boot_config_override=
@@ -277,4 +277,4 @@ else
 fi
 
 # shellcheck disable=SC2086
-exec "$executable_path" $rest_args
+exec "$executable_path" $rest_args | tee -a debug.log


### PR DESCRIPTION
I got debugging working on linux with these changes. Excuse my Kotlin, I have now written like 50 lines of it.

I STRONGLY recommend switching to Doorstop 4.3.0 for Linux. The 4.0.0 version has a hard dependency on a specific version of glibc. The hard glibc requirement will mean that a huge number of Linux users won't be able to use the plugin.