### PR TITLE
Add support for Keyed Translation Files

### DIFF
--- a/example-mod/.idea/.idea.AshAndDust/.idea/.name
+++ b/example-mod/.idea/.idea.AshAndDust/.idea/.name
@@ -1,1 +1,0 @@
-AshAndDust

--- a/example-mod/.idea/.idea.AshAndDust/.idea/encodings.xml
+++ b/example-mod/.idea/.idea.AshAndDust/.idea/encodings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
-</project>

--- a/example-mod/.idea/.idea.AshAndDust/.idea/indexLayout.xml
+++ b/example-mod/.idea/.idea.AshAndDust/.idea/indexLayout.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="UserContentModel">
-    <attachedFolders />
-    <explicitIncludes />
-    <explicitExcludes />
-  </component>
-</project>

--- a/example-mod/.idea/.idea.AshAndDust/.idea/vcs.xml
+++ b/example-mod/.idea/.idea.AshAndDust/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
-  </component>
-</project>

--- a/example-mod/Source/AshAndDust.csproj
+++ b/example-mod/Source/AshAndDust.csproj
@@ -33,7 +33,7 @@
           <Private>False</Private>
         </Reference>
         <Reference Include="Assembly-CSharp">
-          <HintPath>D:\SteamLibrary\steamapps\common\RimWorld\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
+          <HintPath>..\..\..\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
           <Private>False</Private>
         </Reference>
         <Reference Include="System" />
@@ -41,7 +41,7 @@
         <Reference Include="System.Data" />
         <Reference Include="System.Xml" />
         <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-          <HintPath>D:\SteamLibrary\steamapps\common\RimWorld\RimWorldWin64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+          <HintPath>..\..\..\RimWorldWin64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
           <Private>False</Private>
         </Reference>
     </ItemGroup>

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ContextActions/StringToKeyedTranslationAction.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ContextActions/StringToKeyedTranslationAction.cs
@@ -56,6 +56,9 @@ public class StringToKeyedTranslationAction(ICSharpContextActionDataProvider pro
 
     public override bool IsAvailable(IUserDataHolder cache)
     {
+        if (!ScopeHelper.IsRimworldProject())
+            return false;
+        
         var selectedElement = provider.GetSelectedElement<IStringLiteralOwner>();
 
         if (selectedElement is null) return false;
@@ -86,6 +89,9 @@ public class StringToKeyedTranslationWorkflow([NotNull] ISolution solution, [Can
 
     public override bool IsAvailable(IDataContext context)
     {
+        if (!ScopeHelper.IsRimworldProject())
+            return false;
+        
         return true;
     }
 

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ContextActions/StringToKeyedTranslationAction.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ContextActions/StringToKeyedTranslationAction.cs
@@ -151,6 +151,7 @@ public class StringToKeyedTranslationRefactoringPage : SingleBeRefactoringPage
 
 // TODO: If the file isn't referencing Verse yet, we need to insert that reference
 // TODO: Allow the user to select the file they want to add the key to
+// TODO: Add an option to insert the XML into all languages defined, not just the default language
 public class StringToKeyedTranslationRefactoring(
     [NotNull] StringToKeyedTranslationWorkflow workflow,
     [NotNull] ISolution solution,

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ContextActions/StringToKeyedTranslationAction.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ContextActions/StringToKeyedTranslationAction.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using JetBrains.Annotations;
+using JetBrains.Application.DataContext;
+using JetBrains.Application.Help;
+using JetBrains.Application.Progress;
+using JetBrains.Application.UI.Actions.ActionManager;
+using JetBrains.DataFlow;
+using JetBrains.IDE.UI;
+using JetBrains.IDE.UI.Extensions;
+using JetBrains.Lifetimes;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.ContextActions;
+using JetBrains.ReSharper.Feature.Services.CSharp.ContextActions;
+using JetBrains.ReSharper.Feature.Services.Refactorings;
+using JetBrains.ReSharper.Feature.Services.UI.Validation;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Tree;
+using JetBrains.ReSharper.Psi.Files;
+using JetBrains.ReSharper.Psi.Paths;
+using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.Util;
+using JetBrains.ReSharper.Psi.Xml.Impl.Tree;
+using JetBrains.ReSharper.Psi.Xml.Parsing;
+using JetBrains.ReSharper.Psi.Xml.Tree;
+using JetBrains.Rider.Model.UIAutomation;
+using JetBrains.TextControl;
+using JetBrains.Util;
+
+namespace ReSharperPlugin.RimworldDev.ContextActions;
+
+[ContextAction(Description = "Move to Keyed Translation", GroupType = typeof (CSharpContextActions), Name = "StringToKeyedTranslation",
+    Priority = 1)]
+public class StringToKeyedTranslationAction(ICSharpContextActionDataProvider provider) : ContextActionBase
+{
+    public override string Text => "Move to Keyed Translation";
+
+    protected override Action<ITextControl> ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
+    {
+        var selectedElement = provider.GetSelectedElement<IStringLiteralOwner>();
+
+        return (_) =>
+        {
+            using var lifetimeDefinition = Lifetime.Define(Lifetime.Eternal);
+            var withDataRules = JetBrains.ReSharper.Resources.Shell.Shell.Instance.GetComponent<IActionManager>()
+                .DataContexts.CreateWithDataRules(lifetimeDefinition.Lifetime);
+
+            var workflow = new StringToKeyedTranslationWorkflow(solution, null, selectedElement);
+
+            RefactoringActionUtil.ExecuteRefactoring(withDataRules, workflow);            
+        };
+    }
+
+    public override bool IsAvailable(IUserDataHolder cache)
+    {
+        var selectedElement = provider.GetSelectedElement<IStringLiteralOwner>();
+
+        if (selectedElement is null) return false;
+        if (selectedElement.Parent is IReferenceExpression
+            {
+                LastChild: IIdentifier { Name: "Translate" }
+            }) return false;
+
+        if (selectedElement is IInterpolatedStringExpression interpolatedStringExpression)
+        {
+            return !interpolatedStringExpression.Inserts.Any(insert => insert.Expression is not IReferenceExpression);
+        }
+
+        return selectedElement is ICSharpLiteralExpression;
+    }
+}
+
+public class StringToKeyedTranslationWorkflow([NotNull] ISolution solution, [CanBeNull] string actionId, ITreeNode selectedElement)
+    : DrivenRefactoringWorkflow(solution, actionId)
+{
+    public StringToKeyedTranslationDataModel DataModel;
+    public StringToKeyedTranslationDataProvider DataProvider = new ("");
+    
+    public override bool Initialize(IDataContext context)
+    {
+        return true;
+    }
+
+    public override bool IsAvailable(IDataContext context)
+    {
+        return true;
+    }
+
+    public override HelpId HelpKeyword => HelpId.Empty;
+
+    public override IRefactoringPage FirstPendingRefactoringPage => new StringToKeyedTranslationRefactoringPage(this);
+
+    public override bool MightModifyManyDocuments => true;
+    public override string Title => "Move to Keyed Translation";
+    public override RefactoringActionGroup ActionGroup => RefactoringActionGroup.Convert;
+
+    public override IRefactoringExecuter CreateRefactoring(IRefactoringDriver driver)
+    {
+        DataModel = new StringToKeyedTranslationDataModel(selectedElement);
+        
+        return new StringToKeyedTranslationRefactoring(this, solution, driver);
+    }
+}
+
+public class StringToKeyedTranslationDataModel(ITreeNode stringExpression) : IDataModel
+{
+    public ITreeNode StringExpression { get; } = stringExpression;
+}
+
+public class StringToKeyedTranslationDataProvider(string name) : IDataProvider
+{
+    public string Name = name;
+
+    public bool NonInteractive => true;
+}
+
+public class StringToKeyedTranslationRefactoringPage : SingleBeRefactoringPage
+{
+    private readonly BeGrid content;
+    private StringToKeyedTranslationWorkflow workflow;
+    public IProperty<string> Name { get; }
+    
+    public StringToKeyedTranslationRefactoringPage(StringToKeyedTranslationWorkflow workflow) : base(workflow.WorkflowExecuterLifetime)
+    {
+        this.workflow = workflow;
+        
+        Name = new Property<string>( "StringToKeyedTranslation.Name", "");
+        
+        var component = workflow.GetComponent<IconHostBase>();
+        var nameControl = Name.GetBeTextBox(Lifetime).WithTextNotEmpty(
+            Lifetime,
+            ValidationStates.validationError.GetIcon(component)
+        );
+
+        content = new BeControl[1]
+        {
+            nameControl.WithDescription("Key Name", Lifetime)
+        }.GetGrid();
+    }
+
+    public override BeControl GetPageContent() => content;
+
+    public override void Commit()
+    {
+        workflow.DataProvider = new StringToKeyedTranslationDataProvider(Name.Value);
+    }
+}
+
+// TODO: If the file isn't referencing Verse yet, we need to insert that reference
+// TODO: Allow the user to select the file they want to add the key to
+public class StringToKeyedTranslationRefactoring(
+    [NotNull] StringToKeyedTranslationWorkflow workflow,
+    [NotNull] ISolution solution,
+    [NotNull] IRefactoringDriver driver)
+    : DrivenRefactoringBase<StringToKeyedTranslationWorkflow>(workflow, solution, driver)
+{
+    public override bool Execute(IProgressIndicator pi)
+    {
+        var selectedElement = Workflow.DataModel.StringExpression;
+        if (selectedElement is not ICSharpExpression csharpExpression) return false;
+        
+        var textToTranslate = "";
+        var arguments = new List<string>();
+
+        if (selectedElement is ICSharpLiteralExpression literalExpression)
+        {
+            textToTranslate = literalExpression.GetUnquotedText();
+        }
+
+        if (selectedElement is IInterpolatedStringExpression interpolatedStringExpression)
+        {
+            if (!Regex.IsMatch(interpolatedStringExpression.GetUnquotedText(), "^\\$\".*"))
+                return false;
+
+            textToTranslate = Regex.Replace(interpolatedStringExpression.GetUnquotedText(), "^\\$\"(.*)$", "$1");
+            
+            arguments = interpolatedStringExpression
+                .Inserts
+                .Select(insert =>
+                {
+                    if (insert.Expression is not IReferenceExpression referenceExpression)
+                        return "";
+
+                    return insert.GetText();
+                })
+                .Where(argument => !string.IsNullOrEmpty(argument))
+                .Distinct()
+                .ToList();
+        }
+        
+        var translationKey = Workflow.DataProvider.Name;
+        
+        var invocation = CSharpElementFactory
+            .GetInstance(csharpExpression)
+            .CreateExpression($"\"$0\".Translate({String.Join(", ", arguments)})", Workflow.DataProvider.Name);
+
+        var rimworldProject = Solution
+            .GetTopLevelProjects()
+            .FirstOrDefault(project => project.ProjectFileLocation.FullPath.EndsWith("About.xml"));
+        
+        if (rimworldProject == null)
+            return false;
+        
+        var languagesFolder = rimworldProject.GetSubItems().FirstOrDefault(item => item.Name == "Languages");
+        if (languagesFolder == null)
+            return false;
+        
+        var translationFiles = rimworldProject
+            .GetAllProjectFiles()
+            .Where(file => file.Location.FullPath.StartsWith(languagesFolder.Location.FullPath));
+        
+        var firstFile = translationFiles.FirstOrDefault();
+        if (firstFile == null)
+            return false;
+        
+        var psiFile = rimworldProject.GetPsiSourceFileInProject(firstFile.Location).GetPrimaryPsiFile();
+        if (psiFile is not XmlFile xmlFile)
+            return false;
+        
+        var languageDataTag = xmlFile.GetNestedTags<IXmlTag>("LanguageData").FirstOrDefault();
+        if (languageDataTag == null)
+            return false;
+        
+        var lastTag = languageDataTag.Children().Last(tag => tag is IXmlTag);
+        
+        for (var index = 0; index < arguments.Count; index++)
+        {
+            var argument = arguments[index];
+            
+            textToTranslate = textToTranslate.FullReplace("{" + argument + "}", "{" + index + "}");
+        }
+        
+        var newTag = XmlElementFactory.GetInstance(languageDataTag).CreateTagForTag(languageDataTag, $"<{translationKey}>{textToTranslate}</{translationKey}>");
+        
+        csharpExpression.ReplaceBy(invocation);
+        ModificationUtil.AddChildAfter(languageDataTag, lastTag, newTag);
+        
+        return true;
+    }
+}

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ContextActions/StringToKeyedTranslationAction.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ContextActions/StringToKeyedTranslationAction.cs
@@ -8,6 +8,7 @@ using JetBrains.Application.Help;
 using JetBrains.Application.Progress;
 using JetBrains.Application.UI.Actions.ActionManager;
 using JetBrains.DataFlow;
+using JetBrains.DocumentManagers.Transactions;
 using JetBrains.IDE.UI;
 using JetBrains.IDE.UI.Extensions;
 using JetBrains.Lifetimes;
@@ -15,6 +16,7 @@ using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.ContextActions;
 using JetBrains.ReSharper.Feature.Services.CSharp.ContextActions;
 using JetBrains.ReSharper.Feature.Services.Refactorings;
+using JetBrains.ReSharper.Feature.Services.UI.Automation;
 using JetBrains.ReSharper.Feature.Services.UI.Validation;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
@@ -26,13 +28,15 @@ using JetBrains.ReSharper.Psi.Util;
 using JetBrains.ReSharper.Psi.Xml.Impl.Tree;
 using JetBrains.ReSharper.Psi.Xml.Parsing;
 using JetBrains.ReSharper.Psi.Xml.Tree;
+using JetBrains.ReSharper.Refactorings.Move.Common;
 using JetBrains.Rider.Model.UIAutomation;
 using JetBrains.TextControl;
 using JetBrains.Util;
 
 namespace ReSharperPlugin.RimworldDev.ContextActions;
 
-[ContextAction(Description = "Move to Keyed Translation", GroupType = typeof (CSharpContextActions), Name = "StringToKeyedTranslation",
+[ContextAction(Description = "Move to Keyed Translation", GroupType = typeof(CSharpContextActions),
+    Name = "StringToKeyedTranslation",
     Priority = 1)]
 public class StringToKeyedTranslationAction(ICSharpContextActionDataProvider provider) : ContextActionBase
 {
@@ -50,7 +54,7 @@ public class StringToKeyedTranslationAction(ICSharpContextActionDataProvider pro
 
             var workflow = new StringToKeyedTranslationWorkflow(solution, null, selectedElement);
 
-            RefactoringActionUtil.ExecuteRefactoring(withDataRules, workflow);            
+            RefactoringActionUtil.ExecuteRefactoring(withDataRules, workflow);
         };
     }
 
@@ -58,7 +62,7 @@ public class StringToKeyedTranslationAction(ICSharpContextActionDataProvider pro
     {
         if (!ScopeHelper.IsRimworldProject())
             return false;
-        
+
         var selectedElement = provider.GetSelectedElement<IStringLiteralOwner>();
 
         if (selectedElement is null) return false;
@@ -76,12 +80,24 @@ public class StringToKeyedTranslationAction(ICSharpContextActionDataProvider pro
     }
 }
 
-public class StringToKeyedTranslationWorkflow([NotNull] ISolution solution, [CanBeNull] string actionId, ITreeNode selectedElement)
+public class StringToKeyedTranslationWorkflow(
+    [NotNull] ISolution solution,
+    [CanBeNull] string actionId,
+    ITreeNode selectedElement)
     : DrivenRefactoringWorkflow(solution, actionId)
 {
     public StringToKeyedTranslationDataModel DataModel;
-    public StringToKeyedTranslationDataProvider DataProvider = new ("");
-    
+    public StringToKeyedTranslationDataProvider DataProvider = new(
+        "", 
+        ((IProjectFolder) solution
+            .GetTopLevelProjects()
+            .FirstOrDefault(project => project.ProjectFileLocation.FullPath.EndsWith("About.xml"))
+            ?.GetSubItems()
+            ?.FirstOrDefault(item => item.Name == "Languages"))
+            ?.GetSubItemRecursively("Keyed") as IProjectFolder,
+        ""
+    );
+
     public override bool Initialize(IDataContext context)
     {
         return true;
@@ -91,7 +107,7 @@ public class StringToKeyedTranslationWorkflow([NotNull] ISolution solution, [Can
     {
         if (!ScopeHelper.IsRimworldProject())
             return false;
-        
+
         return true;
     }
 
@@ -105,20 +121,34 @@ public class StringToKeyedTranslationWorkflow([NotNull] ISolution solution, [Can
 
     public override IRefactoringExecuter CreateRefactoring(IRefactoringDriver driver)
     {
-        DataModel = new StringToKeyedTranslationDataModel(selectedElement);
-        
+        var rimworldProject = Solution
+            .GetTopLevelProjects()
+            .FirstOrDefault(project => project.ProjectFileLocation.FullPath.EndsWith("About.xml"));
+
+        IProjectItem languagesFolder = null;
+
+        if (rimworldProject is not null)
+        {
+            languagesFolder = rimworldProject.GetSubItems().FirstOrDefault(item => item.Name == "Languages");
+        }
+
+        DataModel = new StringToKeyedTranslationDataModel(selectedElement, languagesFolder);
+
         return new StringToKeyedTranslationRefactoring(this, solution, driver);
     }
 }
 
-public class StringToKeyedTranslationDataModel(ITreeNode stringExpression) : IDataModel
+public class StringToKeyedTranslationDataModel(ITreeNode stringExpression, IProjectItem languagesFolder) : IDataModel
 {
     public ITreeNode StringExpression { get; } = stringExpression;
+    public IProjectItem LanguagesFolder { get; } = languagesFolder;
 }
 
-public class StringToKeyedTranslationDataProvider(string name) : IDataProvider
+public class StringToKeyedTranslationDataProvider(string name, IProjectFolder languagesFolder, string newFileName) : IDataProvider
 {
     public string Name = name;
+    public IProjectFolder LanguagesFolder = languagesFolder;
+    public string NewFileName = newFileName;
 
     public bool NonInteractive => true;
 }
@@ -128,22 +158,44 @@ public class StringToKeyedTranslationRefactoringPage : SingleBeRefactoringPage
     private readonly BeGrid content;
     private StringToKeyedTranslationWorkflow workflow;
     public IProperty<string> Name { get; }
-    
-    public StringToKeyedTranslationRefactoringPage(StringToKeyedTranslationWorkflow workflow) : base(workflow.WorkflowExecuterLifetime)
+    public IProperty<string> NewFileName { get; }
+    public IProperty<string> NewFileExtension { get; }
+        
+    public StringToKeyedTranslationRefactoringPage(StringToKeyedTranslationWorkflow workflow) : base(
+        workflow.WorkflowExecuterLifetime)
     {
         this.workflow = workflow;
-        
-        Name = new Property<string>( "StringToKeyedTranslation.Name", "");
-        
+        var error = ValidationIcons.Error;
+
+        Name = new Property<string>("StringToKeyedTranslation.Name", "");
+        NewFileName = new Property<string>("StringToKeyedTranslation.NewFileName", "AndAndDust.xml");
+        NewFileExtension = new Property<string>("StringToKeyedTranslation.NewFileExtension", "");
+
         var component = workflow.GetComponent<IconHostBase>();
         var nameControl = Name.GetBeTextBox(Lifetime).WithTextNotEmpty(
             Lifetime,
             ValidationStates.validationError.GetIcon(component)
         );
 
-        content = new BeControl[1]
+        var location = workflow.DataProvider.LanguagesFolder.Location;
+        
+        var fileControl = BeUtil
+            .GetPropertyWithHandler(
+                Lifetime,
+                "MoveToFile.Name",
+                v => NewFileName.SetValue(v), NewFileName.Value
+            )
+            .GetBeTextBox(Lifetime)
+            .WithTextNotEmpty(Lifetime, error)
+            .WithValidFileName(Lifetime, error, true)
+            .WithAllowedExtensions(".xml", Lifetime, error)
+            .WithFileCompletion(workflow.Solution, Lifetime, ".xml", location)
+        ;
+
+        content = new[]
         {
-            nameControl.WithDescription("Key Name", Lifetime)
+            nameControl.WithDescription("Key Name", Lifetime),
+            fileControl.WithDescription("Translation File", Lifetime)
         }.GetGrid();
     }
 
@@ -151,13 +203,15 @@ public class StringToKeyedTranslationRefactoringPage : SingleBeRefactoringPage
 
     public override void Commit()
     {
-        workflow.DataProvider = new StringToKeyedTranslationDataProvider(Name.Value);
+        workflow.DataProvider = new StringToKeyedTranslationDataProvider(Name.Value, workflow.DataProvider.LanguagesFolder, NewFileName.Value);
     }
 }
 
 // TODO: If the file isn't referencing Verse yet, we need to insert that reference
-// TODO: Allow the user to select the file they want to add the key to
 // TODO: Add an option to insert the XML into all languages defined, not just the default language
+// TODO: When the user adds a translation to a new file and then Undoes that action, it leaves a broken file in the project
+// TODO: Pull the language to add to from the ScopeHelper
+// TODO: Create the languages folder if it doesn't exist yet
 public class StringToKeyedTranslationRefactoring(
     [NotNull] StringToKeyedTranslationWorkflow workflow,
     [NotNull] ISolution solution,
@@ -168,7 +222,7 @@ public class StringToKeyedTranslationRefactoring(
     {
         var selectedElement = Workflow.DataModel.StringExpression;
         if (selectedElement is not ICSharpExpression csharpExpression) return false;
-        
+
         var textToTranslate = "";
         var arguments = new List<string>();
 
@@ -183,7 +237,7 @@ public class StringToKeyedTranslationRefactoring(
                 return false;
 
             textToTranslate = Regex.Replace(interpolatedStringExpression.GetUnquotedText(), "^\\$\"(.*)$", "$1");
-            
+
             arguments = interpolatedStringExpression
                 .Inserts
                 .Select(insert =>
@@ -197,54 +251,56 @@ public class StringToKeyedTranslationRefactoring(
                 .Distinct()
                 .ToList();
         }
-        
+
         var translationKey = Workflow.DataProvider.Name;
-        
+
         var invocation = CSharpElementFactory
             .GetInstance(csharpExpression)
             .CreateExpression($"\"$0\".Translate({String.Join(", ", arguments)})", Workflow.DataProvider.Name);
+        
+        var folder = Workflow.DataProvider.LanguagesFolder;
+        var fileName = Workflow.DataProvider.NewFileName;
 
-        var rimworldProject = Solution
-            .GetTopLevelProjects()
-            .FirstOrDefault(project => project.ProjectFileLocation.FullPath.EndsWith("About.xml"));
-        
-        if (rimworldProject == null)
-            return false;
-        
-        var languagesFolder = rimworldProject.GetSubItems().FirstOrDefault(item => item.Name == "Languages");
-        if (languagesFolder == null)
-            return false;
-        
-        var translationFiles = rimworldProject
-            .GetAllProjectFiles()
-            .Where(file => file.Location.FullPath.StartsWith(languagesFolder.Location.FullPath));
-        
-        var firstFile = translationFiles.FirstOrDefault();
-        if (firstFile == null)
-            return false;
-        
-        var psiFile = rimworldProject.GetPsiSourceFileInProject(firstFile.Location).GetPrimaryPsiFile();
+        var translationFile = folder.GetSubItems(fileName).FirstOrDefault();
+        if (translationFile is null)
+        {
+            using var transactionCookie = folder.GetSolution().CreateTransactionCookie(DefaultAction.Commit, "Create file copy", NullProgressIndicator.Create());
+            if (!transactionCookie.CanAddFile(folder, folder.Location.Combine(fileName), out string _))
+                return false;
+            translationFile = transactionCookie.AddFile(folder, folder.Location.Combine(fileName));
+
+            if (translationFile.GetProject().GetPsiSourceFileInProject(translationFile.Location)
+                    .GetPrimaryPsiFile() is not IXmlFile newXmlFile)
+                return false;
+
+            var newLanguageDataTag = XmlElementFactory.GetInstance(newXmlFile).CreateRootTag("<LanguageData></LanguageData>");
+            newXmlFile.AddTagAfter(newLanguageDataTag, null);
+        }
+
+        var psiFile = folder.GetProject().GetPsiSourceFileInProject(translationFile.Location).GetPrimaryPsiFile();
         if (psiFile is not XmlFile xmlFile)
             return false;
-        
+
         var languageDataTag = xmlFile.GetNestedTags<IXmlTag>("LanguageData").FirstOrDefault();
         if (languageDataTag == null)
             return false;
-        
-        var lastTag = languageDataTag.Children().Last(tag => tag is IXmlTag);
-        
+
+        var lastTag = languageDataTag.Children().LastOrDefault(tag => tag is IXmlTag)
+                      ?? languageDataTag.Children().Last().PrevSibling;
+
         for (var index = 0; index < arguments.Count; index++)
         {
             var argument = arguments[index];
-            
+
             textToTranslate = textToTranslate.FullReplace("{" + argument + "}", "{" + index + "}");
         }
-        
-        var newTag = XmlElementFactory.GetInstance(languageDataTag).CreateTagForTag(languageDataTag, $"<{translationKey}>{textToTranslate}</{translationKey}>");
-        
+
+        var newTag = XmlElementFactory.GetInstance(languageDataTag).CreateTagForTag(languageDataTag,
+            $"<{translationKey}>{textToTranslate}</{translationKey}>");
+
         csharpExpression.ReplaceBy(invocation);
         ModificationUtil.AddChildAfter(languageDataTag, lastTag, newTag);
-        
+
         return true;
     }
 }

--- a/src/dotnet/ReSharperPlugin.RimworldDev/Generator/DefGenerator.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/Generator/DefGenerator.cs
@@ -43,6 +43,8 @@ public class GenerateDefPropertiesWorkflowXml : GenerateCodeWorkflowBase
 
     public override bool IsAvailable(IDataContext dataContext)
     {
+        if (!ScopeHelper.IsRimworldProject()) return false;
+        
         var solution = dataContext.GetData(ProjectModelDataConstants.SOLUTION);
         if (solution == null)
             return false;
@@ -57,7 +59,7 @@ public class GenerateDefPropertiesWorkflowXml : GenerateCodeWorkflowBase
     }
     public override bool IsEnabled(ITreeNode context)
     {
-        return true;
+        return ScopeHelper.IsRimworldProject();
     }
 
     public override bool IsEmptyInputAllowed(IGeneratorContext context)
@@ -71,6 +73,8 @@ public class DefPropertiesGeneratorBuilderXml : GeneratorBuilderBase<GeneratorCo
 {
     protected override bool IsAvailable(GeneratorContextBase context)
     {
+        if (!ScopeHelper.IsRimworldProject()) return false;
+        
         var anchor = context.Anchor;
 
         if (anchor is not XmlWhitespaceToken) return false;

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ItemCompletion/RimworldKeyedTranslationsCSharpItemProvider.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ItemCompletion/RimworldKeyedTranslationsCSharpItemProvider.cs
@@ -1,0 +1,58 @@
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.CodeCompletion.Infrastructure;
+using JetBrains.ReSharper.Feature.Services.CodeCompletion.Infrastructure.LookupItems;
+using JetBrains.ReSharper.Feature.Services.CSharp.CodeCompletion.Infrastructure;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Impl.Tree;
+using JetBrains.ReSharper.Psi.CSharp.Parsing;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.Tree;
+using ReSharperPlugin.RimworldDev.SymbolScope;
+using ReSharperPlugin.RimworldDev.TypeDeclaration;
+
+namespace ReSharperPlugin.RimworldDev.ItemCompletion;
+
+[Language(typeof(CSharpLanguage))]
+public class RimworldKeyedTranslationsCSharpItemProvider: ItemsProviderOfSpecificContext<CSharpCodeCompletionContext>
+{
+    private static RimworldCSharpLookupFactory LookupFactory = new();
+    
+    protected override bool IsAvailable(CSharpCodeCompletionContext context)
+    {
+        var node = context.NodeInFile;
+        if (!node.Language.IsLanguage(CSharpLanguage.Instance)) return false;
+        if (node is not CSharpGenericToken) return false;
+        if (node.NodeType != CSharpTokenType.STRING_LITERAL_REGULAR) return false;
+        
+        return true;
+    }
+
+    protected override bool AddLookupItems(CSharpCodeCompletionContext context, IItemsCollector collector)
+    {
+        var node = context.NodeInFile;
+
+        if (node.Parent?.NextSibling?.NextSibling is not ICSharpIdentifier identifier ||
+            identifier.GetText() != "Translate")
+            return false;
+        
+        var xmlSymbolTable = context.NodeInFile.GetSolution().GetComponent<RimworldKeyedTranslationSymbolScope>();
+        
+        foreach (var key in xmlSymbolTable.GetKeys())
+        {
+            var keyTag = xmlSymbolTable.GetKeyTag(key);
+            if (keyTag == null) continue;
+            
+            var lookup = LookupFactory.CreateDeclaredElementLookupItem(
+                context,
+                key,
+                new DeclaredElementInstance(new XMLTagDeclaredElement(keyTag, $"English/{key}", false))
+            );
+            
+            collector.Add(lookup);
+        }
+        
+        return base.AddLookupItems(context, collector);
+    }
+
+}

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ItemCompletion/RimworldKeyedTranslationsCSharpItemProvider.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ItemCompletion/RimworldKeyedTranslationsCSharpItemProvider.cs
@@ -40,13 +40,14 @@ public class RimworldKeyedTranslationsCSharpItemProvider: ItemsProviderOfSpecifi
         
         foreach (var key in xmlSymbolTable.GetKeys())
         {
-            var keyTag = xmlSymbolTable.GetKeyTag(key);
-            if (keyTag == null) continue;
+            var nullableKeyTag = xmlSymbolTable.GetTranslationKey(key);
+            if (!nullableKeyTag.HasValue) continue;
+            var keyTag = nullableKeyTag.Value;
             
             var lookup = LookupFactory.CreateDeclaredElementLookupItem(
                 context,
                 key,
-                new DeclaredElementInstance(new XMLTagDeclaredElement(keyTag, $"English/{key}", false))
+                new DeclaredElementInstance(new XMLTagDeclaredElement(keyTag.Tag, $"{keyTag.Language}/{keyTag.KeyName}", false))
             );
             
             collector.Add(lookup);

--- a/src/dotnet/ReSharperPlugin.RimworldDev/Navigation/RimworldSearcherFactory.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/Navigation/RimworldSearcherFactory.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.ExtensionsAPI;
 using JetBrains.ReSharper.Psi.Search;
 using JetBrains.ReSharper.Psi.Xml;
@@ -10,7 +11,8 @@ namespace ReSharperPlugin.RimworldDev.Navigation;
 [PsiSharedComponent]
 public class RimworldSearcherFactory(SearchDomainFactory searchDomainFactory) : DomainSpecificSearcherFactoryBase
 {
-    public override bool IsCompatibleWithLanguage(PsiLanguageType languageType) => languageType.Is<XmlLanguage>();
+    public override bool IsCompatibleWithLanguage(PsiLanguageType languageType) => 
+        languageType.Is<XmlLanguage>() || languageType.Is<CSharpLanguage>();
 
     public override ISearchDomain GetDeclaredElementSearchDomain(IDeclaredElement declaredElement)
     {
@@ -21,8 +23,7 @@ public class RimworldSearcherFactory(SearchDomainFactory searchDomainFactory) : 
         IDeclaredElementsSet elements,
         ReferenceSearcherParameters referenceSearcherParameters)
     {
-        elements = new DeclaredElementsSet(elements.Where(element =>
-            IsCompatibleWithLanguage(element.PresentationLanguage)));
+        elements = new DeclaredElementsSet(elements.Where(element => element.PresentationLanguage.Is<XmlLanguage>()));
         
         return new CustomSearcher(this, elements, referenceSearcherParameters, false);
     }

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ProblemAnalyzers/CustomXmlAnalysisStageProcess.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ProblemAnalyzers/CustomXmlAnalysisStageProcess.cs
@@ -30,6 +30,8 @@ public sealed class CustomXmlAnalysisStageProcess : XmlDaemonStageProcessBase, I
 
     public override void Execute([InstantHandle] Action<DaemonStageResult> committer)
     {
+        if (!ScopeHelper.IsRimworldProject()) return;
+        
         File.ProcessDescendants(this);
         committer(new DaemonStageResult(myConsumer.CollectHighlightings()));
     }

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ProblemAnalyzers/KeyedTranslationAnalysis.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ProblemAnalyzers/KeyedTranslationAnalysis.cs
@@ -57,6 +57,8 @@ public class KeyedTranslationAnalysisStage : CSharpDaemonStageBase
 
         public override void Execute(Action<DaemonStageResult> committer)
         {
+            if (!ScopeHelper.IsRimworldProject()) return;
+            
             File.ProcessDescendants(this);
             committer(new DaemonStageResult(myConsumer.CollectHighlightings()));
         }

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ProblemAnalyzers/KeyedTranslationAnalysis.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ProblemAnalyzers/KeyedTranslationAnalysis.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Text.RegularExpressions;
 using JetBrains.Annotations;
 using JetBrains.Application.Parts;
@@ -87,7 +88,11 @@ public class KeyedTranslationAnalysisStage : CSharpDaemonStageBase
 
             var translation = symbolScope.GetTranslationKey(translationKey).Value!.Tag.InnerText;
 
-            var matches = Regex.Matches(translation, @"(\{\d+\})");
+            var matches = Regex
+                .Matches(translation, @"(\{\d+\})")
+                .Select(match => match.Value)
+                .Distinct()
+                .ToList();
 
             if (matches.Count != argumentCount)
             {

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ProblemAnalyzers/KeyedTranslationAnalysis.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ProblemAnalyzers/KeyedTranslationAnalysis.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Text.RegularExpressions;
+using JetBrains.Annotations;
+using JetBrains.Application.Parts;
+using JetBrains.Application.Settings;
+using JetBrains.DocumentModel;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Daemon.AspRouteTemplates.Highlightings;
+using JetBrains.ReSharper.Daemon.CSharp.Errors;
+using JetBrains.ReSharper.Daemon.CSharp.Stages;
+using JetBrains.ReSharper.Daemon.UsageChecking;
+using JetBrains.ReSharper.Feature.Services.CSharp.Daemon;
+using JetBrains.ReSharper.Feature.Services.Daemon;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.Util;
+using ReSharperPlugin.RimworldDev.SymbolScope;
+
+namespace ReSharperPlugin.RimworldDev.ProblemAnalyzers;
+
+[DaemonStage(
+    Instantiation.DemandAnyThreadSafe,
+    StagesBefore = [typeof(LanguageSpecificDaemonStage), typeof(CollectUsagesStage)],
+    HighlightingTypes = [typeof(KeyedTranslationAnalysisProcessStage)]
+)]
+public class KeyedTranslationAnalysisStage : CSharpDaemonStageBase
+{
+    protected override IDaemonStageProcess CreateProcess(
+        IDaemonProcess process,
+        IContextBoundSettingsStore settings,
+        DaemonProcessKind processKind,
+        ICSharpFile file
+    )
+    {
+        return new KeyedTranslationAnalysisProcessStage(process, file);
+    }
+
+    [HighlightingSource(HighlightingTypes = [typeof (MethodMissingRouteParametersHighlighting)])]
+    public class KeyedTranslationAnalysisProcessStage : CSharpDaemonStageProcessBase, IRecursiveElementProcessor
+    {
+        [NotNull] private readonly IHighlightingConsumer myConsumer;
+        [NotNull] private readonly RimworldKeyedTranslationSymbolScope symbolScope;
+
+        public KeyedTranslationAnalysisProcessStage([NotNull] IDaemonProcess process,
+            [NotNull] ICSharpFile file) : base(process, file)
+        {
+            symbolScope = file.GetSolution().GetComponent<RimworldKeyedTranslationSymbolScope>();
+            
+            myConsumer = new FilteringHighlightingConsumer(
+                DaemonProcess.SourceFile, 
+                File, 
+                DaemonProcess.ContextBoundSettingsStore
+            );
+        }
+
+        public override void Execute(Action<DaemonStageResult> committer)
+        {
+            File.ProcessDescendants(this);
+            committer(new DaemonStageResult(myConsumer.CollectHighlightings()));
+        }
+
+        public bool InteriorShouldBeProcessed(ITreeNode element)
+        {
+            return true;
+        }
+
+        void IRecursiveElementProcessor.ProcessBeforeInterior(ITreeNode element)
+        {
+        }
+
+        public void ProcessAfterInterior(ITreeNode element)
+        {
+            if (element is not IIdentifier { Name: "Translate" }) return;
+            if (element.Parent?.Parent is not IInvocationExpression invocation) return;
+            if (element.Parent?.FirstChild is not ICSharpLiteralExpression translationStringElement) return;
+
+            var translationKey = translationStringElement.GetUnquotedText();
+            var arguments = invocation.ArgumentList;
+            var argumentCount = arguments.Arguments.Count;
+
+            if (!symbolScope.HasTranslationKey(translationKey))
+            {
+                AddError("Translation key does not exist", translationStringElement.GetDocumentRange());
+                return;
+            }
+
+            var translation = symbolScope.GetTranslationKey(translationKey).Value!.Tag.InnerText;
+
+            var matches = Regex.Matches(translation, @"(\{\d+\})");
+
+            if (matches.Count != argumentCount)
+            {
+                AddError(
+                    $"Invalid number of arguments. Expected {matches.Count}, Passed in {arguments.Arguments.Count}",
+                    invocation.GetDocumentRange()
+                );
+                return;
+            }
+        }
+
+        bool IRecursiveElementProcessor.ProcessingIsFinished
+        {
+            get
+            {
+                if (base.DaemonProcess.InterruptFlag)
+                    throw new OperationCanceledException();
+                return false;
+            }
+        }
+        
+        private void AddError(string errorText, DocumentRange range)
+        {
+            IHighlighting error = new KeyedTranslationHighlighting(errorText, range);
+
+            myConsumer.AddHighlighting(error, range);
+        }
+    }
+
+    [StaticSeverityHighlighting(Severity.ERROR, typeof(CSharpErrors))]
+    public class KeyedTranslationHighlighting(string tooltip, DocumentRange range) : IHighlighting
+    {
+        public bool IsValid() => true;
+
+        public DocumentRange CalculateRange() => range;
+
+        public string ToolTip => tooltip;
+        public string ErrorStripeToolTip => "test error";
+    }
+}

--- a/src/dotnet/ReSharperPlugin.RimworldDev/QuickDocumentation/KeyedTranslationProvider.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/QuickDocumentation/KeyedTranslationProvider.cs
@@ -88,7 +88,7 @@ public class KeyedTranslationDescriptionProvider : IDeclaredElementDescriptionPr
     {
         if (element is not XMLTagDeclaredElement declaredElement) return new RichTextBlock();
 
-        var block = new RichTextBlock { declaredElement.GetInnerText() };
+        var block = new RichTextBlock { declaredElement.GetText() };
 
         return block;
     }

--- a/src/dotnet/ReSharperPlugin.RimworldDev/QuickDocumentation/KeyedTranslationProvider.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/QuickDocumentation/KeyedTranslationProvider.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Linq;
+using JetBrains.Application.DataContext;
+using JetBrains.Application.UI.Components.Theming;
+using JetBrains.ReSharper.Feature.Services.Descriptions;
+using JetBrains.ReSharper.Feature.Services.Navigation;
+using JetBrains.ReSharper.Feature.Services.QuickDoc;
+using JetBrains.ReSharper.Feature.Services.QuickDoc.Render;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.DataContext;
+using JetBrains.ReSharper.Psi.Modules;
+using JetBrains.UI.RichText;
+using ReSharperPlugin.RimworldDev.TypeDeclaration;
+
+namespace DefaultNamespace;
+
+[QuickDocProvider(1)]
+public class KeyedTranslationProvider(ITheming theming): IQuickDocProvider
+{
+    public bool CanNavigate(IDataContext context)
+    {
+        var data = context.GetData(PsiDataConstants.DECLARED_ELEMENTS_FROM_ALL_CONTEXTS);
+        var tags = data?.Where(element => element is XMLTagDeclaredElement).ToList();
+
+        return tags != null && tags.Count != 0;
+    }
+
+    public void Resolve(IDataContext context, Action<IQuickDocPresenter, PsiLanguageType> resolved)
+    {
+        var data = context.GetData(PsiDataConstants.DECLARED_ELEMENTS_FROM_ALL_CONTEXTS);
+        var tags = data?.Where(element => element is XMLTagDeclaredElement).ToList();
+
+        var presenter =
+            new KeyedTranslationPresenter(theming, tags.First());
+
+        resolved(presenter, CSharpLanguage.Instance);
+    }
+}
+
+public class KeyedTranslationPresenter(ITheming theming, IDeclaredElement element) : IQuickDocPresenter
+{
+    private readonly DeclaredElementEnvoy<IDeclaredElement> myEnvoy = new(element);
+
+    public QuickDocTitleAndText GetHtml(PsiLanguageType presentationLanguage)
+    {
+        var validDeclaredElement = myEnvoy.GetValidDeclaredElement();
+        if (validDeclaredElement == null)
+            return QuickDocTitleAndText.Empty;
+        var presenter = new KeyedTranslationDescriptionProvider();
+        var block = presenter.GetElementDescription(
+            validDeclaredElement, 
+            DeclaredElementDescriptionStyle.FULL_STYLE,
+            presentationLanguage
+        );
+        
+        return new QuickDocTitleAndText(
+            new RichText().FullHtml(_ => { }, body => body.Append(block.ToHtml()), theming),
+            DeclaredElementPresenter.Format(
+                presentationLanguage,
+                DeclaredElementPresenter.FULL_NESTED_NAME_PRESENTER,
+                validDeclaredElement
+            )
+        );
+    }
+
+    public string GetId() => null;
+
+    public IQuickDocPresenter Resolve(string id) => null;
+
+    public void OpenInEditor(string navigationId = "")
+    {
+        IDeclaredElement validDeclaredElement = this.myEnvoy.GetValidDeclaredElement();
+        if (validDeclaredElement == null)
+            return;
+        validDeclaredElement.Navigate(true);
+    }
+
+    public void ReadMore(string navigationId = "")
+    {
+    }
+}
+
+public class KeyedTranslationDescriptionProvider : IDeclaredElementDescriptionProvider
+{
+    public RichTextBlock GetElementDescription(IDeclaredElement element, DeclaredElementDescriptionStyle style,
+        PsiLanguageType language, IPsiModule module = null)
+    {
+        if (element is not XMLTagDeclaredElement declaredElement) return new RichTextBlock();
+
+        var block = new RichTextBlock { declaredElement.GetInnerText() };
+
+        return block;
+    }
+
+    public bool? IsElementObsolete(IDeclaredElement element, out RichTextBlock obsoleteDescription,
+        DeclaredElementDescriptionStyle style)
+    {
+        obsoleteDescription = null;
+        return false;
+    }
+
+    public int Priority => 0;
+}

--- a/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldCSharpKeyedTranslationProvider.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldCSharpKeyedTranslationProvider.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using JetBrains.DataFlow;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
@@ -40,11 +41,15 @@ public class RimworldCSharpKeyedTranslationReferenceFactory : IReferenceFactory
         var key = element.GetUnquotedText();
         var xmlSymbolTable = element.GetSolution().GetComponent<RimworldKeyedTranslationSymbolScope>();
 
-        var tag = xmlSymbolTable.GetKeyTag(key);
-        if (tag is null)
+        if (!xmlSymbolTable.HasTranslationKey(key))
             return new ReferenceCollection();
-        
-        return new ReferenceCollection(new RimworldKeyedTranslationReference(element, tag, "English", key)); 
+
+        var tags = xmlSymbolTable.GetAllTagsForKey(key);
+        return new ReferenceCollection(
+            tags.Select(tag => 
+                new RimworldKeyedTranslationReference(element, tag.Tag, tag.Language, tag.KeyName
+            )).ToList()
+        );
     }
 
     public bool HasReference(ITreeNode element, IReferenceNameContainer names)

--- a/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldCSharpKeyedTranslationProvider.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldCSharpKeyedTranslationProvider.cs
@@ -1,0 +1,55 @@
+using JetBrains.DataFlow;
+using JetBrains.Lifetimes;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.Caches;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.Resolve;
+using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.Util;
+using ReSharperPlugin.RimworldDev.SymbolScope;
+
+namespace ReSharperPlugin.RimworldDev.TypeDeclaration;
+
+[ReferenceProviderFactory]
+public class RimworldCSharpKeyedTranslationProvider : IReferenceProviderFactory
+{
+    public RimworldCSharpKeyedTranslationProvider(Lifetime lifetime) =>
+        Changed = new Signal<IReferenceProviderFactory>(lifetime, GetType().FullName);
+    
+    public IReferenceFactory CreateFactory(IPsiSourceFile sourceFile, IFile file, IWordIndex wordIndexForChecks)
+    {
+        return sourceFile.PrimaryPsiLanguage.Is<CSharpLanguage>()
+            ? new RimworldCSharpKeyedTranslationReferenceFactory()
+            : null;
+    }
+
+    public ISignal<IReferenceProviderFactory> Changed { get; }
+}
+
+public class RimworldCSharpKeyedTranslationReferenceFactory : IReferenceFactory
+{
+    public ReferenceCollection GetReferences(ITreeNode element, ReferenceCollection oldReferences)
+    {
+        if (element is not ICSharpLiteralExpression ||
+            element.NextSibling?.NextSibling is not ICSharpIdentifier identifier ||
+            identifier.GetText() != "Translate")
+            return new ReferenceCollection();
+
+        var key = element.GetUnquotedText();
+        var xmlSymbolTable = element.GetSolution().GetComponent<RimworldKeyedTranslationSymbolScope>();
+
+        var tag = xmlSymbolTable.GetKeyTag(key);
+        if (tag is null)
+            return new ReferenceCollection();
+        
+        return new ReferenceCollection(new RimworldKeyedTranslationReference(element, tag, "English", key)); 
+    }
+
+    public bool HasReference(ITreeNode element, IReferenceNameContainer names)
+    {
+        if (element.NodeType.ToString() != "TEXT") return false;
+        return !element.Parent.GetText().Contains("defName") && names.Contains(element.GetText());
+    }
+}

--- a/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldKeyedTranslationReference.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldKeyedTranslationReference.cs
@@ -1,0 +1,62 @@
+using JetBrains.Annotations;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Resolve;
+using JetBrains.ReSharper.Psi.Resolve;
+using JetBrains.ReSharper.Psi.Tree;
+using ReSharperPlugin.RimworldDev.SymbolScope;
+
+namespace ReSharperPlugin.RimworldDev.TypeDeclaration;
+
+public class RimworldKeyedTranslationReference : TreeReferenceBase<ITreeNode>
+{
+    private readonly ITreeNode myTypeElement;
+
+    private string myName;
+    private string keyName;
+    private string language;
+
+    public RimworldKeyedTranslationReference([NotNull] ITreeNode owner, ITreeNode typeElement, string laguage, string keyName) : base(owner)
+    {
+        myTypeElement = typeElement;
+        myName = $"{laguage}/{keyName}";
+        this.keyName = keyName;
+        this.language = laguage;
+    }
+
+    public override ISymbolTable GetReferenceSymbolTable(bool useReferenceName)
+    {
+        var symbolScope = myOwner.GetSolution().GetComponent<RimworldKeyedTranslationSymbolScope>();
+
+        symbolScope.AddDeclaredElement(
+            myOwner.GetSolution(),
+            myTypeElement,
+            language,
+            keyName,
+            false
+        );
+        
+        return symbolScope.GetSymbolTable(myOwner.GetSolution());
+    }
+
+    public override ResolveResultWithInfo ResolveWithoutCache()
+    {
+        return GetReferenceSymbolTable(true).GetResolveResult(GetName());
+    }
+
+    public override string GetName() => myName;
+
+    public override IReference BindTo(IDeclaredElement element) =>
+        BindTo(element, EmptySubstitution.INSTANCE);
+
+    public override IReference BindTo(
+        IDeclaredElement element,
+        ISubstitution substitution)
+    {
+        return this;
+    }
+
+    public override TreeTextRange GetTreeTextRange() => myOwner.GetTreeTextRange();
+
+    public override IAccessContext GetAccessContext() => new ElementAccessContext(myOwner);
+}

--- a/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldXmlKeyedTranslationReferenceProvider.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldXmlKeyedTranslationReferenceProvider.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using JetBrains.DataFlow;
+using JetBrains.Lifetimes;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.Caches;
+using JetBrains.ReSharper.Psi.Resolve;
+using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.Web.WebConfig;
+using JetBrains.ReSharper.Psi.Xml;
+using JetBrains.ReSharper.Psi.Xml.Impl.Tree;
+using ReSharperPlugin.RimworldDev.SymbolScope;
+
+namespace ReSharperPlugin.RimworldDev.TypeDeclaration;
+
+[ReferenceProviderFactory]
+public class RimworldXmlKeyedTranslationReferenceProviderFactory : IReferenceProviderFactory
+{
+    public RimworldXmlKeyedTranslationReferenceProviderFactory(Lifetime lifetime) =>
+        Changed = new Signal<IReferenceProviderFactory>(lifetime, GetType().FullName);
+
+    public IReferenceFactory CreateFactory(IPsiSourceFile sourceFile, IFile file, IWordIndex wordIndexForChecks)
+    {
+        return sourceFile.PrimaryPsiLanguage.Is<XmlLanguage>() && sourceFile.GetExtensionWithDot()
+            .Equals(".xml", StringComparison.CurrentCultureIgnoreCase)
+            ? new RimworldXmlKeyedTranslationReferenceProvider()
+            : null;
+    }
+
+    public ISignal<IReferenceProviderFactory> Changed { get; }
+}
+
+// This reference provider only serves to attach a reference on the Keyed Translation to itself. It's a hacky workaround
+// to allow us to do Find Usages on Keyed Translations
+public class RimworldXmlKeyedTranslationReferenceProvider : IReferenceFactory
+{
+    public ReferenceCollection GetReferences(ITreeNode element, ReferenceCollection oldReferences)
+    {
+        if (
+            element is not XmlIdentifier identifier ||
+            identifier?.Parent?.Parent?.Parent is not XmlTag { } LangaugeDataTag ||
+            LangaugeDataTag.Children().First() is not XmlTagHeaderNode languageDataHeaderNode ||
+            languageDataHeaderNode.Children().ElementAt(1) is not XmlIdentifier languageDataIdentifier || 
+            languageDataIdentifier.GetText() != "LanguageData"
+        )
+            return new ReferenceCollection();
+        
+        var keyName = identifier.GetText();
+        var xmlSymbolTable = element.GetSolution().GetComponent<RimworldKeyedTranslationSymbolScope>();
+        
+        var tag = xmlSymbolTable.GetKeyTag(keyName);
+        if (tag is null)
+            return new ReferenceCollection();
+
+        return new ReferenceCollection(new RimworldKeyedTranslationReference(element, tag, "English", keyName)); 
+    }
+
+    public bool HasReference(ITreeNode element, IReferenceNameContainer names)
+    {
+        if (element.NodeType.ToString() != "TEXT") return false;
+        return !element.Parent.GetText().Contains("defName") && names.Contains(element.GetText());
+    }
+}

--- a/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldXmlKeyedTranslationReferenceProvider.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/References/RimworldXmlKeyedTranslationReferenceProvider.cs
@@ -49,11 +49,13 @@ public class RimworldXmlKeyedTranslationReferenceProvider : IReferenceFactory
         var keyName = identifier.GetText();
         var xmlSymbolTable = element.GetSolution().GetComponent<RimworldKeyedTranslationSymbolScope>();
         
-        var tag = xmlSymbolTable.GetKeyTag(keyName);
-        if (tag is null)
+        var nullableTag = xmlSymbolTable.GetTranslationKey(keyName);
+        if (nullableTag is null)
             return new ReferenceCollection();
 
-        return new ReferenceCollection(new RimworldKeyedTranslationReference(element, tag, "English", keyName)); 
+        var tag = nullableTag.Value;
+        
+        return new ReferenceCollection(new RimworldKeyedTranslationReference(element, tag.Tag, tag.Language, tag.KeyName)); 
     }
 
     public bool HasReference(ITreeNode element, IReferenceNameContainer names)

--- a/src/dotnet/ReSharperPlugin.RimworldDev/RimworldXmlProject/RimworldXmlProjectHost.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/RimworldXmlProject/RimworldXmlProjectHost.cs
@@ -26,7 +26,7 @@ public class RimworldXmlProjectHost : SolutionFileProjectHostBase
     private readonly FileSystemWildcardService myWildcardService;
     private readonly ProjectFilePropertiesFactory myProjectFilePropertiesFactory;
     private bool hasReloaded = false;
-    
+
     public RimworldXmlProjectHost(
         IPlatformManager platformManager,
         ProjectFilePropertiesFactory projectFilePropertiesFactory,
@@ -40,13 +40,18 @@ public class RimworldXmlProjectHost : SolutionFileProjectHostBase
         myStructureBuilder = new RimworldProjectStructureBuilder(myProjectFilePropertiesFactory);
         myWildcardService = wildcardService;
     }
-    
+
     public override bool IsApplicable(IProjectMark projectMark)
     {
         return projectMark.Guid.ToString() == "f2a71f9b-5d33-465a-a702-920d77279781";
     }
 
-    protected override void Reload(ProjectHostReloadChange change, VirtualFileSystemPath logPath)
+    // To swap between Rider 2025.3 and Rider 2026.1, swap the `override` between these two methods
+    protected void Reload(ProjectHostReloadChange change, FileSystemPath logPath) => Reload(change);
+
+    protected override void Reload(ProjectHostReloadChange change, VirtualFileSystemPath logPath) => Reload(change);
+
+    protected  void Reload(ProjectHostReloadChange change)
     {
         if (change.ProjectMark is not RimworldProjectMark projectMark) return;
 
@@ -70,26 +75,31 @@ public class RimworldXmlProjectHost : SolutionFileProjectHostBase
             {
                 targetFramework
             }, defaultLanguage, EmptyList<Guid>.InstanceList);
-        
+
         // This is a quick fix suggested by Jetbrains to fix where Files/Folders get created when adding them to our project
-        var config = projectProperties.TryGetConfiguration<IManagedProjectConfiguration>(projectProperties.ActiveConfigurations.TargetFrameworkIds.FirstNotNull());
+        var config =
+            projectProperties.TryGetConfiguration<IManagedProjectConfiguration>(projectProperties.ActiveConfigurations
+                .TargetFrameworkIds.FirstNotNull());
         config?.UpdatePropertyCollection(x =>
             x[MSBuildProjectUtil.BaseDirectoryProperty] = projectMark.Location.Parent.Parent.FullPath);
-        
-        var customDescriptor = new RimworldProjectDescriptor(projectMark.Guid, projectProperties, null, projectMark.Name,
+
+        var customDescriptor = new RimworldProjectDescriptor(projectMark.Guid, projectProperties, null,
+            projectMark.Name,
             siteProjectLocation, projectMark.Location);
 
         var byProjectLocation = ProjectDescriptor.CreateWithoutItemsByProjectDescriptor(customDescriptor);
-        
-        myStructureBuilder.Build(byProjectLocation, ProjectFolderFilter.Instance, GetLoadFolders(projectMark.Location.Parent.Parent));
-        myWildcardService.RegisterDirectory(projectMark, siteProjectLocation, targetFramework, ProjectFolderFilter.Instance);
-        
+
+        myStructureBuilder.Build(byProjectLocation, ProjectFolderFilter.Instance,
+            GetLoadFolders(projectMark.Location.Parent.Parent));
+        myWildcardService.RegisterDirectory(projectMark, siteProjectLocation, targetFramework,
+            ProjectFolderFilter.Instance);
+
         change.Descriptors = new ProjectHostChangeDescriptors(byProjectLocation)
         {
             ProjectReferencesDescriptor = BuildReferences(targetFramework, projectMark)
         };
     }
-
+    
     private List<string> GetLoadFolders(VirtualFileSystemPath basePath)
     {
         var loadFolders = new List<string>();
@@ -109,7 +119,7 @@ public class RimworldXmlProjectHost : SolutionFileProjectHostBase
             }
 
             versionList.Sort();
-            
+
             var folderTags = document.GetElementsByTagName(versionList.Last())[0].ChildNodes;
             for (var i = 0; i < folderTags.Count; i++)
             {
@@ -133,16 +143,22 @@ public class RimworldXmlProjectHost : SolutionFileProjectHostBase
         return location;
     }
 
-    private static ProjectReferencesDescriptor BuildReferences([NotNull] TargetFrameworkId targetFrameworkId, [NotNull] IProjectMark projectMark)
+    private static ProjectReferencesDescriptor BuildReferences([NotNull] TargetFrameworkId targetFrameworkId,
+        [NotNull] IProjectMark projectMark)
     {
-        if (projectMark is not RimworldProjectMark rimworldProjectMark || rimworldProjectMark.Dependencies.Count == 0) return null;
+        if (projectMark is not RimworldProjectMark rimworldProjectMark ||
+            rimworldProjectMark.Dependencies.Count == 0) return null;
 
         var pairList = new List<Pair<IProjectReferenceDescriptor, IProjectReferenceProperties>>();
 
         rimworldProjectMark.Dependencies.ForEach(dependency =>
         {
-            var reference = new ProjectToProjectReferenceBySearchDescriptor(targetFrameworkId, dependency.ToProjectSearchDescriptor());
-            pairList.Add(new Pair<IProjectReferenceDescriptor, IProjectReferenceProperties>(reference, ProjectReferenceProperties.Instance) );
+            var reference =
+                new ProjectToProjectReferenceBySearchDescriptor(targetFrameworkId,
+                    dependency.ToProjectSearchDescriptor());
+            pairList.Add(
+                new Pair<IProjectReferenceDescriptor, IProjectReferenceProperties>(reference,
+                    ProjectReferenceProperties.Instance));
         });
 
         return new ProjectReferencesDescriptor(pairList);
@@ -161,6 +177,7 @@ public class RimworldXmlProjectHost : SolutionFileProjectHostBase
             path.Name.Equals("bin", StringComparison.OrdinalIgnoreCase) ||
             path.Name.EndsWith(".DotSettings.user", StringComparison.OrdinalIgnoreCase) ||
             path.Name.Equals("node_modules", StringComparison.OrdinalIgnoreCase) ||
-            !new List<string> {"About", "Defs", "Patches", "Languages", "Sounds", "Textures", "News"}.Any(it => path.FullPath.Contains(it));
+            !new List<string> { "About", "Defs", "Patches", "Languages", "Sounds", "Textures", "News" }.Any(it =>
+                path.FullPath.Contains(it));
     }
 }

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ScopeHelper.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ScopeHelper.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using JetBrains.Annotations;
-using JetBrains.Application.Threading.Tasks;
 using JetBrains.Metadata.Reader.API;
 using JetBrains.ProjectModel;
 using JetBrains.ProjectModel.model2.Assemblies.Interfaces;
@@ -12,8 +11,8 @@ using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Caches;
 using JetBrains.ReSharper.Psi.Modules;
 using JetBrains.ReSharper.Psi.Util;
+using JetBrains.ReSharper.Resources.Shell;
 using JetBrains.Util;
-using JetBrains.Util.Threading.Tasks;
 using ReSharperPlugin.RimworldDev.Settings;
 
 namespace ReSharperPlugin.RimworldDev;
@@ -48,11 +47,14 @@ public class ScopeHelper
 
                 if (rimworldScope == null)
                 {
-                    AddRef(solution);
+                    using (WriteLockCookie.Create())
+                    {
+                        AddRef(solution);
+                    }
 
                     return false;
                 }
-
+                
                 rimworldModule = solution.PsiModules().GetModules()
                     .First(module =>
                         module.GetPsiServices().Symbols.GetSymbolScope(module, true, true)
@@ -90,8 +92,9 @@ public class ScopeHelper
         var moduleReferenceResolveContext =
             (IModuleReferenceResolveContext)UniversalModuleReferenceContext.Instance;
 
-        await solution.Locks.Tasks.YieldTo(solution.GetSolutionLifetimes().MaximumLifetime, Scheduling.MainDispatcher,
-            TaskPriority.Low);
+        // await solution.Locks.Tasks.YieldTo(solution.GetSolutionLifetimes().MaximumLifetime,
+        //     Scheduling.MainDispatcher,
+        //     TaskPriority.Low);
 
         solution.GetComponent<IAssemblyFactory>().AddRef(path.ToAssemblyLocation(), "ScopeHelper::AddRef",
             moduleReferenceResolveContext);

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ScopeHelper.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ScopeHelper.cs
@@ -25,12 +25,21 @@ public class ScopeHelper
     private static IPsiModule rimworldModule;
     private static List<ISymbolScope> usedScopes;
     private static bool adding = false;
+    private static bool? isRimworldProject = false;
+
+    public static bool IsRimworldProject() => isRimworldProject ?? false;
 
     public static bool UpdateScopes(ISolution solution)
     {
         if (solution == null) return false;
         using (CompilationContextCookie.GetOrCreate(UniversalModuleReferenceContext.Instance))
         {
+            if (isRimworldProject == null)
+            {
+                isRimworldProject = solution.GetTopLevelProjects()
+                    .Any(project => project.ProjectFileLocation.EndsWith("About.xml"));
+            }
+            
             allScopes = solution.PsiModules().GetModules().Select(module =>
                 module.GetPsiServices().Symbols.GetSymbolScope(module, true, true)).ToList();
 
@@ -61,6 +70,7 @@ public class ScopeHelper
                             .GetTypeElementByCLRName("Verse.ThingDef") != null);
             }
 
+            isRimworldProject = true;
             return true;
         }
     }

--- a/src/dotnet/ReSharperPlugin.RimworldDev/ScopeHelper.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/ScopeHelper.cs
@@ -25,7 +25,7 @@ public class ScopeHelper
     private static IPsiModule rimworldModule;
     private static List<ISymbolScope> usedScopes;
     private static bool adding = false;
-    private static bool? isRimworldProject = false;
+    private static bool? isRimworldProject;
 
     public static bool IsRimworldProject() => isRimworldProject ?? false;
 

--- a/src/dotnet/ReSharperPlugin.RimworldDev/SymbolScope/RimworldKeyedTranslationSymbol.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/SymbolScope/RimworldKeyedTranslationSymbol.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.Serialization;
+using JetBrains.Util.PersistentMap;
+
+namespace ReSharperPlugin.RimworldDev.SymbolScope;
+
+public class RimworldKeyedTranslationSymbol
+{
+    public static readonly IUnsafeMarshaller<List<RimworldKeyedTranslationSymbol>> Marshaller =
+        UnsafeMarshallers.GetCollectionMarshaller(new UniversalMarshaller<RimworldKeyedTranslationSymbol>(Read, Write), (size) => new List<RimworldKeyedTranslationSymbol>());
+    
+    public string KeyName { get; }
+    public string Langauge { get; }
+
+    public int DocumentOffset { get; }
+    
+    public RimworldKeyedTranslationSymbol(ITreeNode tag, string keyName, string language)
+    {
+        KeyName = keyName;
+        Langauge = language;
+        DocumentOffset = tag.GetTreeStartOffset().Offset;
+    }
+    
+    public RimworldKeyedTranslationSymbol(int documentOffset, string keyName, string language)
+    {
+        KeyName = keyName;
+        Langauge = language;
+        DocumentOffset = documentOffset;
+    }
+    
+    private static RimworldKeyedTranslationSymbol Read(UnsafeReader reader)
+    {
+        var keyName = reader.ReadString();
+        var langauge = reader.ReadString();
+        var documentOffset = reader.ReadInt();
+        
+        return new RimworldKeyedTranslationSymbol(documentOffset, langauge, keyName);
+    }
+
+    private static void Write(UnsafeWriter writer, RimworldKeyedTranslationSymbol value)
+    {
+        writer.Write(value.KeyName);
+        writer.Write(value.Langauge);
+        writer.Write(value.DocumentOffset);
+    }
+}

--- a/src/dotnet/ReSharperPlugin.RimworldDev/SymbolScope/RimworldKeyedTranslationSymbol.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/SymbolScope/RimworldKeyedTranslationSymbol.cs
@@ -35,7 +35,7 @@ public class RimworldKeyedTranslationSymbol
         var langauge = reader.ReadString();
         var documentOffset = reader.ReadInt();
         
-        return new RimworldKeyedTranslationSymbol(documentOffset, langauge, keyName);
+        return new RimworldKeyedTranslationSymbol(documentOffset, keyName, langauge);
     }
 
     private static void Write(UnsafeWriter writer, RimworldKeyedTranslationSymbol value)

--- a/src/dotnet/ReSharperPlugin.RimworldDev/SymbolScope/RimworldKeyedTranslationSymbolScope.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/SymbolScope/RimworldKeyedTranslationSymbolScope.cs
@@ -18,30 +18,72 @@ using ReSharperPlugin.RimworldDev.TypeDeclaration;
 
 namespace ReSharperPlugin.RimworldDev.SymbolScope;
 
+public struct TranslationKey
+{
+    public TranslationKey(string language, string keyName, IXmlTag tag)
+    {
+        Language = language;
+        KeyName = keyName;
+        Tag = tag;
+    }
+    
+    public string Language { get; }
+    public string KeyName { get; }
+    
+    public IXmlTag Tag { get; }
+}
+
 [PsiComponent(Instantiation.ContainerAsyncPrimaryThread)]
 public class RimworldKeyedTranslationSymbolScope: SimpleICache<List<RimworldKeyedTranslationSymbol>>
 {
-    private Dictionary<string, Dictionary<string, IXmlTag>> KeyedTranslations = new();
-    private Dictionary<string, XMLTagDeclaredElement> _declaredElements = new();
-    private SymbolTable _symbolTable;
+    private Dictionary<string, Dictionary<string, TranslationKey>> keyedTranslations;
+    private Dictionary<string, XMLTagDeclaredElement> declaredElements = new();
+    private SymbolTable symbolTable;
 
+    private string defaultLanguage = "English";
+    private string ideLanguage = "English";
+    
     public List<string> GetKeys()
     {
-        if (!KeyedTranslations.ContainsKey("English"))
-            KeyedTranslations["English"] = new Dictionary<string, IXmlTag>();
-
-        return KeyedTranslations["English"].Keys.ToList();
+        var keys = new List<string>();
+        foreach (var language in keyedTranslations.Values)
+        {
+            keys.AddRange(language.Keys);
+        }
+        
+        return keys.Distinct().ToList();
     }
 
-    public IXmlTag GetKeyTag(string key)
+    public TranslationKey? GetTranslationKey(string key)
     {
-        if (!KeyedTranslations.ContainsKey("English"))
-            KeyedTranslations["English"] = new Dictionary<string, IXmlTag>();
+        if (!keyedTranslations.ContainsKey(ideLanguage))
+            keyedTranslations[ideLanguage] = new ();
 
-        if (!KeyedTranslations["English"].ContainsKey(key))
+        if (!keyedTranslations[ideLanguage].ContainsKey(key))
             return null;
 
-        return KeyedTranslations["English"][key];
+        return keyedTranslations[ideLanguage][key];
+    }
+
+    public List<TranslationKey> GetAllTagsForKey(string key)
+    {
+        var tags = new List<TranslationKey>();
+        
+        foreach (var language in keyedTranslations.Values)
+        {
+            if (!language.ContainsKey(key)) continue;
+            tags.Add(language[key]);
+        }
+
+        return tags;
+    }
+
+    public bool HasTranslationKey(string key)
+    {
+        if (keyedTranslations[ideLanguage].ContainsKey(key)) return true;
+        if (ideLanguage != defaultLanguage && keyedTranslations[defaultLanguage].ContainsKey(key)) return true;
+
+        return keyedTranslations.Any(language => language.Value.ContainsKey(key));
     }
     
     public RimworldKeyedTranslationSymbolScope(
@@ -51,6 +93,15 @@ public class RimworldKeyedTranslationSymbolScope: SimpleICache<List<RimworldKeye
         long? version = null
     ) : base(lifetime, locks, persistentIndexManager, RimworldKeyedTranslationSymbol.Marshaller, version)
     {
+        keyedTranslations = new()
+        {
+            { defaultLanguage, new() },
+        };
+
+        if (defaultLanguage != ideLanguage)
+        {
+            keyedTranslations.Add(ideLanguage, new());
+        }
     }
 
     public override object Build(IPsiSourceFile sourceFile, bool isStartup)
@@ -101,8 +152,8 @@ public class RimworldKeyedTranslationSymbolScope: SimpleICache<List<RimworldKeye
 
         items?.ForEach(item =>
         {
-            if (KeyedTranslations.ContainsKey(item.Langauge) && KeyedTranslations[item.Langauge].ContainsKey(item.KeyName))
-                KeyedTranslations[item.Langauge].Remove(item.KeyName);
+            if (keyedTranslations.ContainsKey(item.Langauge) && keyedTranslations[item.Langauge].ContainsKey(item.KeyName))
+                keyedTranslations[item.Langauge].Remove(item.KeyName);
         });
     }
 
@@ -128,13 +179,15 @@ public class RimworldKeyedTranslationSymbolScope: SimpleICache<List<RimworldKeye
 
     private void AddKeyToList(RimworldKeyedTranslationSymbol item, IXmlTag xmlTag)
     {
-        if (!KeyedTranslations.ContainsKey(item.Langauge))
-            KeyedTranslations[item.Langauge] = new Dictionary<string, IXmlTag>();
+        if (!keyedTranslations.ContainsKey(item.Langauge))
+            keyedTranslations[item.Langauge] = new ();
+
+        var translationKey = new TranslationKey(item.Langauge, item.KeyName, xmlTag);
         
-        if (!KeyedTranslations[item.Langauge].ContainsKey(item.KeyName))
-            KeyedTranslations[item.Langauge].Add(item.KeyName, xmlTag);
+        if (!keyedTranslations[item.Langauge].ContainsKey(item.KeyName))
+            keyedTranslations[item.Langauge].Add(item.KeyName, translationKey);
         else
-            KeyedTranslations[item.Langauge][item.KeyName] = xmlTag;
+            keyedTranslations[item.Langauge][item.KeyName] = translationKey;
     }
 
     protected override bool IsApplicable(IPsiSourceFile sourceFile)
@@ -149,11 +202,11 @@ public class RimworldKeyedTranslationSymbolScope: SimpleICache<List<RimworldKeye
         string keyName,
         bool caseSensitiveName)
     {
-        if (_symbolTable == null) _symbolTable = new SymbolTable(solution.GetPsiServices());
+        if (symbolTable == null) symbolTable = new SymbolTable(solution.GetPsiServices());
 
-        if (_declaredElements.ContainsKey($"{language}/{keyName}"))
+        if (declaredElements.ContainsKey($"{language}/{keyName}"))
         {
-            _declaredElements[$"{language}/{keyName}"].Update(owner);
+            declaredElements[$"{language}/{keyName}"].Update(owner);
             return;
         }
 
@@ -164,14 +217,14 @@ public class RimworldKeyedTranslationSymbolScope: SimpleICache<List<RimworldKeye
         );
 
         // @TODO: We seem to get "Key Already Exists" errors. Race condition?
-        _declaredElements.Add($"{language}/{keyName}", declaredElement);
-        _symbolTable.AddSymbol(declaredElement);
+        declaredElements.Add($"{language}/{keyName}", declaredElement);
+        symbolTable.AddSymbol(declaredElement);
     }
 
     public ISymbolTable GetSymbolTable(ISolution solution)
     {
-        if (_symbolTable == null) _symbolTable = new SymbolTable(solution.GetPsiServices());
+        if (symbolTable == null) symbolTable = new SymbolTable(solution.GetPsiServices());
 
-        return _symbolTable;
+        return symbolTable;
     }
 }

--- a/src/dotnet/ReSharperPlugin.RimworldDev/SymbolScope/RimworldKeyedTranslationSymbolScope.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/SymbolScope/RimworldKeyedTranslationSymbolScope.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using JetBrains;
 using JetBrains.Annotations;
 using JetBrains.Application.Parts;
@@ -56,13 +57,19 @@ public class RimworldKeyedTranslationSymbolScope: SimpleICache<List<RimworldKeye
     {
         if (!IsApplicable(sourceFile)) return null;
         if (sourceFile.GetPrimaryPsiFile() is not IXmlFile xmlFile) return null;
+        if (!sourceFile.DisplayName.Contains("Languages")) return null;
 
+        var languageMatch = Regex.Match(sourceFile.DisplayName, @"Languages\\(.*?)\\Keyed");
+        if (!languageMatch.Success) return null;
+
+        var language = languageMatch.Groups[1].Value;
+        
         var tags = xmlFile.GetNestedTags<IXmlTag>("LanguageData/*").Where(tag => true);
 
         var symbols = tags.Select(tag => new RimworldKeyedTranslationSymbol(
             tag,
             tag.GetName().XmlName,
-            "English"
+            language
         )).ToList();
 
         if (symbols.Count == 0) return null;

--- a/src/dotnet/ReSharperPlugin.RimworldDev/SymbolScope/RimworldKeyedTranslationSymbolScope.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/SymbolScope/RimworldKeyedTranslationSymbolScope.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains;
+using JetBrains.Annotations;
+using JetBrains.Application.Parts;
+using JetBrains.Application.Threading;
+using JetBrains.Lifetimes;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.Caches;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Resolve;
+using JetBrains.ReSharper.Psi.Files;
+using JetBrains.ReSharper.Psi.Resolve;
+using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.Xml.Tree;
+using ReSharperPlugin.RimworldDev.TypeDeclaration;
+
+namespace ReSharperPlugin.RimworldDev.SymbolScope;
+
+[PsiComponent(Instantiation.ContainerAsyncPrimaryThread)]
+public class RimworldKeyedTranslationSymbolScope: SimpleICache<List<RimworldKeyedTranslationSymbol>>
+{
+    private Dictionary<string, Dictionary<string, IXmlTag>> KeyedTranslations = new();
+    private Dictionary<string, XMLTagDeclaredElement> _declaredElements = new();
+    private SymbolTable _symbolTable;
+
+    public List<string> GetKeys()
+    {
+        if (!KeyedTranslations.ContainsKey("English"))
+            KeyedTranslations["English"] = new Dictionary<string, IXmlTag>();
+
+        return KeyedTranslations["English"].Keys.ToList();
+    }
+
+    public IXmlTag GetKeyTag(string key)
+    {
+        if (!KeyedTranslations.ContainsKey("English"))
+            KeyedTranslations["English"] = new Dictionary<string, IXmlTag>();
+
+        if (!KeyedTranslations["English"].ContainsKey(key))
+            return null;
+
+        return KeyedTranslations["English"][key];
+    }
+    
+    public RimworldKeyedTranslationSymbolScope(
+        Lifetime lifetime, 
+        [NotNull] IShellLocks locks, 
+        [NotNull] IPersistentIndexManager persistentIndexManager, 
+        long? version = null
+    ) : base(lifetime, locks, persistentIndexManager, RimworldKeyedTranslationSymbol.Marshaller, version)
+    {
+    }
+
+    public override object Build(IPsiSourceFile sourceFile, bool isStartup)
+    {
+        if (!IsApplicable(sourceFile)) return null;
+        if (sourceFile.GetPrimaryPsiFile() is not IXmlFile xmlFile) return null;
+
+        var tags = xmlFile.GetNestedTags<IXmlTag>("LanguageData/*").Where(tag => true);
+
+        var symbols = tags.Select(tag => new RimworldKeyedTranslationSymbol(
+            tag,
+            tag.GetName().XmlName,
+            "English"
+        )).ToList();
+
+        if (symbols.Count == 0) return null;
+        return symbols;
+    }
+    
+    public override void Merge(IPsiSourceFile sourceFile, object builtPart)
+    {
+        RemoveFromLocalCache(sourceFile);
+        AddToLocalCache(sourceFile, builtPart as List<RimworldKeyedTranslationSymbol>);
+        base.Merge(sourceFile, builtPart);
+    }
+
+    public override void MergeLoaded(object data)
+    {
+        PopulateLocalCache();
+        base.MergeLoaded(data);
+    }
+
+    public override void Drop(IPsiSourceFile sourceFile)
+    {
+        RemoveFromLocalCache(sourceFile);
+        base.Drop(sourceFile);
+    }
+    
+    private void RemoveFromLocalCache(IPsiSourceFile sourceFile)
+    {
+        var items = Map!.GetValueSafe(sourceFile);
+
+        items?.ForEach(item =>
+        {
+            if (KeyedTranslations.ContainsKey(item.Langauge) && KeyedTranslations[item.Langauge].ContainsKey(item.KeyName))
+                KeyedTranslations[item.Langauge].Remove(item.KeyName);
+        });
+    }
+
+    private void PopulateLocalCache()
+    {
+        foreach (var (sourceFile, cacheItem) in Map)
+            AddToLocalCache(sourceFile, cacheItem);
+    }
+
+    private void AddToLocalCache(IPsiSourceFile sourceFile, [CanBeNull] List<RimworldKeyedTranslationSymbol> cacheItem)
+    {
+        if (sourceFile.GetPrimaryPsiFile() is not IXmlFile xmlFile) return;
+        
+        cacheItem?.ForEach(item =>
+        {
+            var matchingItem = xmlFile.GetNestedTags<IXmlTag>($"LanguageData/{item.KeyName}").FirstOrDefault();
+
+            if (matchingItem is null) return;
+
+            AddKeyToList(item, matchingItem);
+        });
+    }
+
+    private void AddKeyToList(RimworldKeyedTranslationSymbol item, IXmlTag xmlTag)
+    {
+        if (!KeyedTranslations.ContainsKey(item.Langauge))
+            KeyedTranslations[item.Langauge] = new Dictionary<string, IXmlTag>();
+        
+        if (!KeyedTranslations[item.Langauge].ContainsKey(item.KeyName))
+            KeyedTranslations[item.Langauge].Add(item.KeyName, xmlTag);
+        else
+            KeyedTranslations[item.Langauge][item.KeyName] = xmlTag;
+    }
+
+    protected override bool IsApplicable(IPsiSourceFile sourceFile)
+    {
+        return base.IsApplicable(sourceFile) && sourceFile.LanguageType.Name == "XML";
+    }
+    
+    public void AddDeclaredElement(
+        ISolution solution, 
+        ITreeNode owner, 
+        string language, 
+        string keyName,
+        bool caseSensitiveName)
+    {
+        if (_symbolTable == null) _symbolTable = new SymbolTable(solution.GetPsiServices());
+
+        if (_declaredElements.ContainsKey($"{language}/{keyName}"))
+        {
+            _declaredElements[$"{language}/{keyName}"].Update(owner);
+            return;
+        }
+
+        var declaredElement = new XMLTagDeclaredElement(
+            owner,
+            $"{language}/{keyName}",
+            caseSensitiveName
+        );
+
+        // @TODO: We seem to get "Key Already Exists" errors. Race condition?
+        _declaredElements.Add($"{language}/{keyName}", declaredElement);
+        _symbolTable.AddSymbol(declaredElement);
+    }
+
+    public ISymbolTable GetSymbolTable(ISolution solution)
+    {
+        if (_symbolTable == null) _symbolTable = new SymbolTable(solution.GetPsiServices());
+
+        return _symbolTable;
+    }
+}

--- a/src/dotnet/ReSharperPlugin.RimworldDev/SymbolScope/RimworldSymbolScope.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/SymbolScope/RimworldSymbolScope.cs
@@ -3,9 +3,7 @@ using System.Linq;
 using JetBrains;
 using JetBrains.Annotations;
 using JetBrains.Application.Parts;
-using JetBrains.Application.Parts;
 using JetBrains.Application.Threading;
-using JetBrains.Collections;
 using JetBrains.Lifetimes;
 using JetBrains.Metadata.Reader.API;
 using JetBrains.ProjectModel;
@@ -43,9 +41,12 @@ public class RimworldSymbolScope : SimpleICache<List<RimworldXmlDefSymbol>>
     private SymbolTable _symbolTable;
 
     public RimworldSymbolScope
-    (Lifetime lifetime, [NotNull] IShellLocks locks, [NotNull] IPersistentIndexManager persistentIndexManager,
-        long? version = null)
-        : base(lifetime, locks, persistentIndexManager, RimworldXmlDefSymbol.Marshaller, version)
+    (
+        Lifetime lifetime, 
+        [NotNull] IShellLocks locks, 
+        [NotNull] IPersistentIndexManager persistentIndexManager,
+        long? version = null
+    ) : base(lifetime, locks, persistentIndexManager, RimworldXmlDefSymbol.Marshaller, version)
     {
     }
 

--- a/src/dotnet/ReSharperPlugin.RimworldDev/SymbolScope/RimworldXmlDefSymbol.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/SymbolScope/RimworldXmlDefSymbol.cs
@@ -15,8 +15,6 @@ public class RimworldXmlDefSymbol
 
     public int DocumentOffset { get; }
     
-    // public IXmlTag Tag { get; }
-
     public RimworldXmlDefSymbol(ITreeNode tag, string defName, string defType)
     {
         DefName = defName;

--- a/src/dotnet/ReSharperPlugin.RimworldDev/TypeDeclaration/XMLTagDeclaredElement.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/TypeDeclaration/XMLTagDeclaredElement.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Xml;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Tree;
@@ -18,6 +17,15 @@ public class XMLTagDeclaredElement : IDeclaredElement
         this.owner = owner;
         myPsiServices = owner.GetPsiServices();
         ShortName = $"{defType}/{defName}";
+        CaseSensitiveName = caseSensitiveName;
+        PresentationLanguage = owner.Language;
+    }
+
+    public XMLTagDeclaredElement(ITreeNode owner, string keyName, bool caseSensitiveName)
+    {
+        this.owner = owner;
+        myPsiServices = owner.GetPsiServices();
+        ShortName = $"{keyName}";
         CaseSensitiveName = caseSensitiveName;
         PresentationLanguage = owner.Language;
     }

--- a/src/dotnet/ReSharperPlugin.RimworldDev/TypeDeclaration/XMLTagDeclaredElement.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/TypeDeclaration/XMLTagDeclaredElement.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Xml;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.Xml.Impl.Tree;
 using JetBrains.Util;
 using JetBrains.Util.DataStructures;
 
@@ -81,4 +82,6 @@ public class XMLTagDeclaredElement : IDeclaredElement
     public XmlNode GetXMLDoc(bool inherit) => (XmlNode)null;
 
     public XmlNode GetXMLDescriptionSummary(bool inherit) => (XmlNode)null;
+
+    public string GetInnerText() => owner is XmlTag ownerTag ? ownerTag.InnerText : owner.GetText();
 }

--- a/src/dotnet/ReSharperPlugin.RimworldDev/TypeDeclaration/XMLTagDeclaredElement.cs
+++ b/src/dotnet/ReSharperPlugin.RimworldDev/TypeDeclaration/XMLTagDeclaredElement.cs
@@ -79,9 +79,11 @@ public class XMLTagDeclaredElement : IDeclaredElement
 
     public IPsiServices GetPsiServices() => myPsiServices;
 
-    public XmlNode GetXMLDoc(bool inherit) => (XmlNode)null;
+    public XmlNode GetXMLDoc(bool inherit) => null;
 
-    public XmlNode GetXMLDescriptionSummary(bool inherit) => (XmlNode)null;
+    public XmlNode GetXMLDescriptionSummary(bool inherit) => null;
 
+    public string GetText() => owner.GetText();
+    
     public string GetInnerText() => owner is XmlTag ownerTag ? ownerTag.InnerText : owner.GetText();
 }


### PR DESCRIPTION
This adds support for Keyed Translation Files and using those Keys in C#:

 * [x] Autocomplete translation keys in `"Key".Translate()"`
 * [x] Navigate to that key with Ctrl+Click from C#
 * [x] Perform a Find Usages on the key from XML or C#
 * [x] Add a problem analyser to detect when an incorrect number of arguments is passed into `Translate`
 * [x] Add a hover over the Keys in C# to display the translation text
 * [ ] If possible, show that translation text in the IDEs default language
 * [ ] Add an intention in C# strings to extract a string into a translation key