### PR TITLE
Pass Commandline Options to RimWorld in Debug

### DIFF
--- a/src/rider/main/kotlin/run/RunConfiguration.kt
+++ b/src/rider/main/kotlin/run/RunConfiguration.kt
@@ -106,6 +106,7 @@ class RunConfiguration(project: Project, factory: ConfigurationFactory, name: St
             getScriptName(),
             getSaveFilePath(),
             getModListPath(),
+            getCommandLineOptions(),
             getRimworldState(environment),
             UnityDebugRemoteConfiguration(),
             environment,

--- a/src/rider/main/kotlin/run/RunState.kt
+++ b/src/rider/main/kotlin/run/RunState.kt
@@ -24,6 +24,7 @@ class RunState(
     private val rimworldLocation: String,
     private val saveFilePath: String,
     private val modListPath: String,
+    private val commandLineOptions: String,
     private val rimworldState: RunProfileState,
     remoteConfiguration: RemoteConfiguration,
     executionEnvironment: ExecutionEnvironment,
@@ -97,7 +98,10 @@ class RunState(
             val bashScriptPath = "${Path(rimworldLocation).parent}/run.sh"
             withContext(Dispatchers.IO) {
                 val logFile = File(System.getProperty("java.io.tmpdir"), "rimworld-doorstop.log")
-                ProcessBuilder("/bin/sh", bashScriptPath, rimworldLocation)
+                val cmdArgs = mutableListOf("/bin/sh", bashScriptPath, rimworldLocation)
+                val extraArgs = commandLineOptions.split(' ').filter { it.isNotEmpty() }
+                cmdArgs.addAll(extraArgs)
+                ProcessBuilder(cmdArgs)
                     .redirectErrorStream(true)
                     .redirectOutput(logFile)
                     .start()


### PR DESCRIPTION
Noticed that when I ran debug mode, it wasn't passing the `savedatafolder` set in the "Program arguments" field to RimWorld, so it was loading my main settings/saves instead of the mod-specific one. 

Also don't know Kotlin, so code might not be perfect